### PR TITLE
Enhancement add obj type owner

### DIFF
--- a/MFaaP.MFWSClient.Tests/MFWSVaultClassGroupOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultClassGroupOperations.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RestSharp;
+
+namespace MFaaP.MFWSClient.Tests
+{
+	[TestClass]
+	public class MFWSVaultClassGroupOperations
+	{
+
+		#region GetClassGroups
+
+		/// <summary>
+		/// Ensures that a call to <see cref="MFaaP.MFWSClient.MFWSVaultClassGroupOperations.GetClassGroupsAsync"/>
+		/// requests the correct resource address with the correct method.
+		/// </summary>
+		[TestMethod]
+		public async Task GetClassGroupsAsync()
+		{
+			// Create our test runner.
+			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
+
+			// Execute.
+			await runner.MFWSClient.ClassGroupOperations.GetClassGroupsAsync(0);
+
+			// Verify.
+			runner.Verify();
+		}
+
+		/// <summary>
+		/// Ensures that a call to <see cref="MFaaP.MFWSClient.MFWSVaultClassGroupOperations.GetClassGroups"/>
+		/// requests the correct resource address with the correct method.
+		/// </summary>
+		[TestMethod]
+		public void GetClassGroups()
+		{
+			// Create our test runner.
+			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
+
+			// Execute.
+			runner.MFWSClient.ClassGroupOperations.GetClassGroups(0);
+
+			// Verify.
+			runner.Verify();
+		}
+
+		#endregion
+	}
+}

--- a/MFaaP.MFWSClient.Tests/MFWSVaultClassOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultClassOperations.cs
@@ -142,45 +142,6 @@ namespace MFaaP.MFWSClient.Tests
 		/// requests the correct resource address with the correct method.
 		/// </summary>
 		[TestMethod]
-		public async Task GetObjectClassGroupsAsync()
-		{
-			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
-
-			// Execute.
-			await runner.MFWSClient.ClassOperations.GetObjectClassGroupsAsync(0);
-
-			// Verify.
-			runner.Verify();
-		}
-
-		/// <summary>
-		/// Ensures that a call to <see cref="MFaaP.MFWSClient.MFWSVaultClassOperations.GetObjectClasses"/>
-		/// requests the correct resource address with the correct method.
-		/// </summary>
-		[TestMethod]
-		public void GetObjectClassGroups()
-		{
-			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
-
-			// Execute.
-			runner.MFWSClient.ClassOperations.GetObjectClassGroups(0);
-
-			// Verify.
-			runner.Verify();
-		}
-
-		#endregion
-
-
-		#region GetObjectClasses
-
-		/// <summary>
-		/// Ensures that a call to <see cref="MFaaP.MFWSClient.MFWSVaultClassOperations.GetObjectClassesAsync"/>
-		/// requests the correct resource address with the correct method.
-		/// </summary>
-		[TestMethod]
 		public async Task GetObjectClassesAsync()
 		{
 			// Create our test runner.

--- a/MFaaP.MFWSClient.Tests/MFWSVaultClassOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultClassOperations.cs
@@ -142,6 +142,45 @@ namespace MFaaP.MFWSClient.Tests
 		/// requests the correct resource address with the correct method.
 		/// </summary>
 		[TestMethod]
+		public async Task GetObjectClassGroupsAsync()
+		{
+			// Create our test runner.
+			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
+
+			// Execute.
+			await runner.MFWSClient.ClassOperations.GetObjectClassGroupsAsync(0);
+
+			// Verify.
+			runner.Verify();
+		}
+
+		/// <summary>
+		/// Ensures that a call to <see cref="MFaaP.MFWSClient.MFWSVaultClassOperations.GetObjectClasses"/>
+		/// requests the correct resource address with the correct method.
+		/// </summary>
+		[TestMethod]
+		public void GetObjectClassGroups()
+		{
+			// Create our test runner.
+			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
+
+			// Execute.
+			runner.MFWSClient.ClassOperations.GetObjectClassGroups(0);
+
+			// Verify.
+			runner.Verify();
+		}
+
+		#endregion
+
+
+		#region GetObjectClasses
+
+		/// <summary>
+		/// Ensures that a call to <see cref="MFaaP.MFWSClient.MFWSVaultClassOperations.GetObjectClassesAsync"/>
+		/// requests the correct resource address with the correct method.
+		/// </summary>
+		[TestMethod]
 		public async Task GetObjectClassesAsync()
 		{
 			// Create our test runner.

--- a/MFaaP.MFWSClient.Tests/MFaaP.MFWSClient.Tests.csproj
+++ b/MFaaP.MFWSClient.Tests/MFaaP.MFWSClient.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ExtensionMethods\IRestRequestExtensionMethods.cs" />
     <Compile Include="ExtensionMethods\ListParameterExtensionMethods.cs" />
     <Compile Include="MFWSVaultAutomaticMetadataOperations.cs" />
+    <Compile Include="MFWSVaultClassGroupOperations.cs" />
     <Compile Include="MFWSVaultExtensionAuthenticationOperations.cs" />
     <Compile Include="MFWSVaultExternalObjectOperations.cs" />
     <Compile Include="MFWSVaultObjectFileOperations.cs" />

--- a/MFaaP.MFWSClient/MFWSClientBase.cs
+++ b/MFaaP.MFWSClient/MFWSClientBase.cs
@@ -113,6 +113,11 @@ namespace MFaaP.MFWSClient
 		public MFWSVaultClassOperations ClassOperations { get; }
 
 		/// <summary>
+		/// Gets the class operations interface.
+		/// </summary>
+		public MFWSVaultClassGroupOperations ClassGroupOperations { get; }
+
+		/// <summary>
 		/// Gets the property definitions operations interface.
 		/// </summary>
 		public MFWSVaultPropertyDefOperations PropertyDefOperations { get; }
@@ -160,6 +165,7 @@ namespace MFaaP.MFWSClient
 			this.ObjectTypeOperations = new MFWSVaultObjectTypeOperations(this);
 			this.ValueListOperations = new MFWSVaultValueListOperations(this);
 			this.ObjectFileOperations = new MFWSVaultObjectFileOperations(this);
+			this.ClassGroupOperations = new MFWSVaultClassGroupOperations(this);
 			this.ClassOperations = new MFWSVaultClassOperations(this);
 			this.PropertyDefOperations = new MFWSVaultPropertyDefOperations(this);
 			this.AutomaticMetadataOperations = new MFWSVaultAutomaticMetadataOperations(this);
@@ -220,7 +226,7 @@ namespace MFaaP.MFWSClient
 			if (null == acceptLanguages)
 				return;
 
-			// Set the 
+			// Set the
 			this.AddDefaultHeader(MFWSClientBase.AcceptLanguageHttpHeaderName, acceptLanguages);
 		}
 

--- a/MFaaP.MFWSClient/MFWSStructs.cs
+++ b/MFaaP.MFWSClient/MFWSStructs.cs
@@ -1898,6 +1898,16 @@ namespace MFaaP.MFWSClient
         public int OwnerPropertyDef { get; set; }
         
         /// <summary>
+        /// Is this ValueList a sublist of another (eg, does this ValueList have an owner)?
+        /// </summary>
+		public bool HasOwner { get; set; }
+
+        /// <summary>
+        /// If HasOwner is true, Owner will yield the ID of the Owner ValueList.
+        /// </summary>
+		public int Owner { get; set; }
+
+        /// <summary>
         /// Based on M-Files API.
         /// </summary>
         public List<int> ReadOnlyPropertiesDuringInsert { get; set; }

--- a/MFaaP.MFWSClient/MFWSStructs.cs
+++ b/MFaaP.MFWSClient/MFWSStructs.cs
@@ -2510,11 +2510,15 @@ namespace MFaaP.MFWSClient
     public class ClassGroup
     {
 
+		public ClassGroup() { }
+
         /// <summary>
         /// Based on M-Files API.
         /// </summary>
         public string Name { get; set; }
         
+		public List<ExtendedObjectClass> Classes { get; set; }
+
     }
 
     

--- a/MFaaP.MFWSClient/MFWSVaultClassGroupOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultClassGroupOperations.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using RestSharp;
+
+namespace MFaaP.MFWSClient
+{
+	/// <summary>
+	/// Methods to create and modify objects.
+	/// </summary>
+	public class MFWSVaultClassGroupOperations
+		: MFWSVaultOperationsBase
+	{
+		/// <summary>
+		/// Creates a new <see cref="MFWSVaultClassGroupOperations"/> object.
+		/// </summary>
+		/// <param name="client">The client to interact with the server.</param>
+		internal MFWSVaultClassGroupOperations(MFWSClientBase client)
+			: base(client)
+		{
+		}
+
+
+
+		/// <summary>
+        /// Gets a list of all class groups with classes in the vault for a given object type.
+        /// </summary>
+        /// <param name="objectTypeId">The type of the object.</param>
+        /// <param name="token">A cancellation token for the request.</param>
+        /// <returns>All classes in the vault for the supplied object type.</returns>
+        /// <remarks>This may be filtered by the user's permissions.</remarks>
+        public async Task<List<ClassGroup>> GetClassGroupsAsync(int objectTypeId, CancellationToken token = default(CancellationToken))
+        {
+            // Create the request.
+            var request = new RestRequest($"/REST/structure/classes.aspx?objtype={objectTypeId}&bygroup=true");
+
+            // Make the request and get the response.
+            var response = await this.MFWSClient.Get<List<ClassGroup>>(request, token)
+                .ConfigureAwait(false);
+
+            // Return the data.
+            return response.Data;
+        }
+
+        /// <summary>
+        /// Gets a list of all classes in the vault for a given object type.
+        /// </summary>
+        /// <param name="objectTypeId">The type of the object.</param>
+        /// <param name="token">A cancellation token for the request.</param>
+        /// <returns>All classes in the vault for the supplied object type.</returns>
+        /// <remarks>This may be filtered by the user's permissions.</remarks>
+        public List<ClassGroup> GetClassGroups(int objectTypeId, CancellationToken token = default(CancellationToken))
+		{
+			// Execute the async method.
+			return this.GetClassGroupsAsync(objectTypeId, token)
+				.ConfigureAwait(false)
+				.GetAwaiter()
+				.GetResult();
+		}
+
+	}
+
+}

--- a/MFaaP.MFWSClient/MFWSVaultClassOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultClassOperations.cs
@@ -219,44 +219,6 @@ namespace MFaaP.MFWSClient
 				.GetAwaiter()
 				.GetResult();
 		}
-
-
-		/// <summary>
-        /// Gets a list of all class groups with classes in the vault for a given object type.
-        /// </summary>
-        /// <param name="objectTypeId">The type of the object.</param>
-        /// <param name="token">A cancellation token for the request.</param>
-        /// <returns>All classes in the vault for the supplied object type.</returns>
-        /// <remarks>This may be filtered by the user's permissions.</remarks>
-        public async Task<List<ClassGroup>> GetObjectClassGroupsAsync(int objectTypeId, CancellationToken token = default(CancellationToken))
-        {
-            // Create the request.
-            var request = new RestRequest($"/REST/structure/classes.aspx?objtype={objectTypeId}&bygroup=true");
-
-            // Make the request and get the response.
-            var response = await this.MFWSClient.Get<List<ClassGroup>>(request, token)
-                .ConfigureAwait(false);
-
-            // Return the data.
-            return response.Data;
-        }
-
-        /// <summary>
-        /// Gets a list of all classes in the vault for a given object type.
-        /// </summary>
-        /// <param name="objectTypeId">The type of the object.</param>
-        /// <param name="token">A cancellation token for the request.</param>
-        /// <returns>All classes in the vault for the supplied object type.</returns>
-        /// <remarks>This may be filtered by the user's permissions.</remarks>
-        public List<ClassGroup> GetObjectClassGroups(int objectTypeId, CancellationToken token = default(CancellationToken))
-		{
-			// Execute the async method.
-			return this.GetObjectClassGroupsAsync(objectTypeId, token)
-				.ConfigureAwait(false)
-				.GetAwaiter()
-				.GetResult();
-		}
-
 	}
-	
+
 }

--- a/MFaaP.MFWSClient/MFWSVaultClassOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultClassOperations.cs
@@ -220,6 +220,43 @@ namespace MFaaP.MFWSClient
 				.GetResult();
 		}
 
+
+		/// <summary>
+        /// Gets a list of all class groups with classes in the vault for a given object type.
+        /// </summary>
+        /// <param name="objectTypeId">The type of the object.</param>
+        /// <param name="token">A cancellation token for the request.</param>
+        /// <returns>All classes in the vault for the supplied object type.</returns>
+        /// <remarks>This may be filtered by the user's permissions.</remarks>
+        public async Task<List<ClassGroup>> GetObjectClassGroupsAsync(int objectTypeId, CancellationToken token = default(CancellationToken))
+        {
+            // Create the request.
+            var request = new RestRequest($"/REST/structure/classes.aspx?objtype={objectTypeId}&bygroup=true");
+
+            // Make the request and get the response.
+            var response = await this.MFWSClient.Get<List<ClassGroup>>(request, token)
+                .ConfigureAwait(false);
+
+            // Return the data.
+            return response.Data;
+        }
+
+        /// <summary>
+        /// Gets a list of all classes in the vault for a given object type.
+        /// </summary>
+        /// <param name="objectTypeId">The type of the object.</param>
+        /// <param name="token">A cancellation token for the request.</param>
+        /// <returns>All classes in the vault for the supplied object type.</returns>
+        /// <remarks>This may be filtered by the user's permissions.</remarks>
+        public List<ClassGroup> GetObjectClassGroups(int objectTypeId, CancellationToken token = default(CancellationToken))
+		{
+			// Execute the async method.
+			return this.GetObjectClassGroupsAsync(objectTypeId, token)
+				.ConfigureAwait(false)
+				.GetAwaiter()
+				.GetResult();
+		}
+
 	}
 	
 }


### PR DESCRIPTION
The REST webservice JSON response for getting valuelists contains HasOwner and Owner, but this isn't deserialized into the ObjType because of missing HasOwner and Owner properties. It is crucial information for finding which class groups contain which classes.