### PR TITLE
added functionality to set workflow state through API PUT call

### DIFF
--- a/MFaaP.MFWSClient.Tests/MFWSVaultObjectPropertyOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultObjectPropertyOperations.cs
@@ -650,6 +650,43 @@ namespace MFaaP.MFWSClient.Tests
 		}
 
 		#endregion
+		
+		#region Set workflow states
+        [TestMethod]
+        public async Task SetWorkflowStateAsync()
+        {
+            var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
 
+            runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
+            // Execute.
+            await runner.MFWSClient.ObjectPropertyOperations.SetWorkflowStateAsync(new ObjVer()
+            {
+                Type = 0,
+                ID = 1,
+                Version = 2
+            }, 2);
+
+            // Verify.
+            runner.Verify();
+        }
+
+        [TestMethod]
+        public void SetWorkflowState()
+        {
+            var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
+
+            runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
+            // Execute.
+            runner.MFWSClient.ObjectPropertyOperations.SetWorkflowState(new ObjVer()
+            {
+                Type = 0,
+                ID = 1,
+                Version = 2
+            }, 2);
+
+            // Verify.
+            runner.Verify();
+        }
+        #endregion
 	}
 }

--- a/MFaaP.MFWSClient.Tests/MFWSVaultWorkflowOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultWorkflowOperations.cs
@@ -8,44 +8,6 @@ namespace MFaaP.MFWSClient.Tests
 	[TestClass]
 	public class MFWSVaultWorkflowOperations
 	{
-		#region Set workflow states
-        [TestMethod]
-        public async Task SetWorkflowStateAsync()
-        {
-            var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
-
-            runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
-            // Execute.
-            await runner.MFWSClient.WorkflowOperations.SetWorkflowStateAsync(new ObjVer()
-            {
-                Type = 0,
-                ID = 1,
-                Version = 2
-            }, 2);
-
-            // Verify.
-            runner.Verify();
-        }
-
-        [TestMethod]
-        public void SetWorkflowState()
-        {
-            var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
-
-            runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
-            // Execute.
-            runner.MFWSClient.WorkflowOperations.SetWorkflowState(new ObjVer()
-            {
-                Type = 0,
-                ID = 1,
-                Version = 2
-            }, 2);
-
-            // Verify.
-            runner.Verify();
-        }
-        #endregion
-		
 		#region Get workflow states
 
 		/// <summary>

--- a/MFaaP.MFWSClient.Tests/MFWSVaultWorkflowOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultWorkflowOperations.cs
@@ -8,6 +8,44 @@ namespace MFaaP.MFWSClient.Tests
 	[TestClass]
 	public class MFWSVaultWorkflowOperations
 	{
+		#region Set workflow states
+        [TestMethod]
+        public async Task SetWorkflowStateAsync()
+        {
+            var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
+
+            runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
+            // Execute.
+            await runner.MFWSClient.WorkflowOperations.SetWorkflowStateAsync(new ObjVer()
+            {
+                Type = 0,
+                ID = 1,
+                Version = 2
+            }, 2);
+
+            // Verify.
+            runner.Verify();
+        }
+
+        [TestMethod]
+        public void SetWorkflowState()
+        {
+            var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
+
+            runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
+            // Execute.
+            runner.MFWSClient.WorkflowOperations.SetWorkflowState(new ObjVer()
+            {
+                Type = 0,
+                ID = 1,
+                Version = 2
+            }, 2);
+
+            // Verify.
+            runner.Verify();
+        }
+        #endregion
+		
 		#region Get workflow states
 
 		/// <summary>

--- a/MFaaP.MFWSClient/MFWSVaultObjectPropertyOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultObjectPropertyOperations.cs
@@ -630,6 +630,47 @@ namespace MFaaP.MFWSClient
 
 		#endregion
 
+		#region Set workflow states
+		
+		/// <summary>
+		/// Sets Workflow state of the object
+		/// </summary>
+		/// <param name="objVer">The Id and version of the object.</param>
+		/// <param name="stateId">workflow State ID which needs to be set</param>
+		/// <param name="token">A cancellation token for the request.</param>
+		/// <returns>A representation of the updated object version</returns>
+		public async Task<ObjectVersion> SetWorkflowStateAsync(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
+		{
+			// Sanity.
+			if (null == objVer)
+				throw new ArgumentNullException(nameof(objVer));
+
+			// Create the request.
+			var request = new RestRequest($"/REST/objects/{objVer.Type}/{objVer.ID}/{objVer.Version}/workflowstate");
+			request.Method = Method.PUT;
+			request.AddJsonBody(new ObjectWorkflowState() { StateID=stateId});
+			// Execute the request and parse the response.
+			var response = await this.MFWSClient.Put<ExtendedObjectVersion>(request, token).ConfigureAwait(false);
+
+			return response.Data;
+		}
+
+		/// <summary>
+		/// Sets Workflow state of the object
+		/// </summary>
+		/// <param name="objVer">The Id and version of the object.</param>
+		/// <param name="stateId">workflow State ID which needs to be set</param>
+		/// <param name="token">A cancellation token for the request.</param>
+		/// <returns>A representation of the updated object version</returns>
+		public ObjectVersion SetWorkflowState(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
+		{
+			return this.SetWorkflowStateAsync(objVer,stateId, token)
+				.ConfigureAwait(false)
+				.GetAwaiter()
+				.GetResult();
+		}
+		#endregion
+
 	}
 
 }

--- a/MFaaP.MFWSClient/MFWSVaultWorkflowOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultWorkflowOperations.cs
@@ -21,6 +21,48 @@ namespace MFaaP.MFWSClient
 		{
 		}
 
+
+		#region Set workflow states
+		
+		/// <summary>
+		/// Sets Workflow state of the object
+		/// </summary>
+		/// <param name="objVer">The Id and version of the object.</param>
+		/// <param name="stateId">workflow State ID which needs to be set</param>
+		/// <param name="token">A cancellation token for the request.</param>
+		/// <returns>A representation of the updated object version</returns>
+		public async Task<ObjectVersion> SetWorkflowStateAsync(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
+		{
+			// Sanity.
+			if (null == objVer)
+				throw new ArgumentNullException(nameof(objVer));
+
+			// Create the request.
+			var request = new RestRequest($"/REST/objects/{objVer.Type}/{objVer.ID}/{objVer.Version}/workflowstate");
+			request.Method = Method.PUT;
+			request.AddJsonBody(new ObjectWorkflowState() { StateID=stateId});
+			// Execute the request and parse the response.
+			var response = await this.MFWSClient.Put<ExtendedObjectVersion>(request, token).ConfigureAwait(false);
+
+			return response.Data;
+		}
+
+		/// <summary>
+		/// Sets Workflow state of the object
+		/// </summary>
+		/// <param name="objVer">The Id and version of the object.</param>
+		/// <param name="stateId">workflow State ID which needs to be set</param>
+		/// <param name="token">A cancellation token for the request.</param>
+		/// <returns>A representation of the updated object version</returns>
+		public ObjectVersion SetWorkflowState(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
+		{
+			return this.SetWorkflowStateAsync(objVer,stateId, token)
+				.ConfigureAwait(false)
+				.GetAwaiter()
+				.GetResult();
+		}
+		#endregion
+
 		#region Get workflow states
 
 		/// <summary>

--- a/MFaaP.MFWSClient/MFWSVaultWorkflowOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultWorkflowOperations.cs
@@ -21,48 +21,6 @@ namespace MFaaP.MFWSClient
 		{
 		}
 
-
-		#region Set workflow states
-		
-		/// <summary>
-		/// Sets Workflow state of the object
-		/// </summary>
-		/// <param name="objVer">The Id and version of the object.</param>
-		/// <param name="stateId">workflow State ID which needs to be set</param>
-		/// <param name="token">A cancellation token for the request.</param>
-		/// <returns>A representation of the updated object version</returns>
-		public async Task<ObjectVersion> SetWorkflowStateAsync(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
-		{
-			// Sanity.
-			if (null == objVer)
-				throw new ArgumentNullException(nameof(objVer));
-
-			// Create the request.
-			var request = new RestRequest($"/REST/objects/{objVer.Type}/{objVer.ID}/{objVer.Version}/workflowstate");
-			request.Method = Method.PUT;
-			request.AddJsonBody(new ObjectWorkflowState() { StateID=stateId});
-			// Execute the request and parse the response.
-			var response = await this.MFWSClient.Put<ExtendedObjectVersion>(request, token).ConfigureAwait(false);
-
-			return response.Data;
-		}
-
-		/// <summary>
-		/// Sets Workflow state of the object
-		/// </summary>
-		/// <param name="objVer">The Id and version of the object.</param>
-		/// <param name="stateId">workflow State ID which needs to be set</param>
-		/// <param name="token">A cancellation token for the request.</param>
-		/// <returns>A representation of the updated object version</returns>
-		public ObjectVersion SetWorkflowState(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
-		{
-			return this.SetWorkflowStateAsync(objVer,stateId, token)
-				.ConfigureAwait(false)
-				.GetAwaiter()
-				.GetResult();
-		}
-		#endregion
-
 		#region Get workflow states
 
 		/// <summary>


### PR DESCRIPTION
In this request, we can pass in the ObjVer and workflow state ID, to update the workflow state through PUT api call. This way even the user who has read-only access can update the state of the workflow if appropriates permissions are in place