### PR TITLE
Add missing ItemGUID to ValueListItem struct

### DIFF
--- a/MFaaP.MFWSClient/MFWSStructs.cs
+++ b/MFaaP.MFWSClient/MFWSStructs.cs
@@ -2159,8 +2159,12 @@ namespace MFaaP.MFWSClient
         /// Based on M-Files API.
         /// </summary>
         public int ValueListID { get; set; }
-        
-    }
+
+		/// <summary>
+		/// Based on M-Files API.
+		/// </summary>
+		public string ItemGUID { get; set; }
+	}
 
     
 


### PR DESCRIPTION
ItemGUID was returned from MFWS but the value wasn't stored in the struct.

