### PR TITLE
Update of RestSharp and dotnet targets

### DIFF
--- a/MFaaP.MFWSClient.Tests/ExtensionMethods/IRestRequestExtensionMethods.cs
+++ b/MFaaP.MFWSClient.Tests/ExtensionMethods/IRestRequestExtensionMethods.cs
@@ -6,7 +6,7 @@ using RestSharp;
 namespace MFaaP.MFWSClient.Tests.ExtensionMethods
 {
 	// ReSharper disable once InconsistentNaming
-	internal static class IRestRequestExtensionMethods
+	internal static class RestRequestExtensionMethods
 	{
 		/// <summary>
 		/// Extracts the body from the request and attempts to deserialize it to the provided type.
@@ -14,7 +14,7 @@ namespace MFaaP.MFWSClient.Tests.ExtensionMethods
 		/// <typeparam name="T">The body type.</typeparam>
 		/// <param name="request">The request.</param>
 		/// <returns>The value, or null.</returns>
-		public static T DeserializeBody<T>(this IRestRequest request)
+		public static T DeserializeBody<T>(this RestRequest request)
 		{
 			// Sanity.
 			if(null == request)

--- a/MFaaP.MFWSClient.Tests/ExtensionMethods/ListParameterExtensionMethods.cs
+++ b/MFaaP.MFWSClient.Tests/ExtensionMethods/ListParameterExtensionMethods.cs
@@ -6,22 +6,18 @@ namespace MFaaP.MFilesAPI.Tests.ExtensionMethods
 {
 	public static class ListParameterExtensionMethods
 	{
-#pragma warning disable CS0618 // Type or member is obsolete
-		public static string GetQuerystringParameter(this List<Parameter> parameters, string name)
-#pragma warning restore CS0618 // Type or member is obsolete
-		{
-			return parameters?
+        public static string GetQuerystringParameter(this List<Parameter> parameters, string name)
+        {
+            return parameters?
 						.Where(p => p.Type == ParameterType.QueryString)
 						.Where(p => p.Name == name)
 						.Select(p => p.Value as string)
 						.FirstOrDefault();
 		}
 
-#pragma warning disable CS0618 // Type or member is obsolete
-		public static string GetMethodQuerystringParameter(this List<Parameter> parameters)
-#pragma warning restore CS0618 // Type or member is obsolete
-		{
-			return parameters.GetQuerystringParameter("_method");
+        public static string GetMethodQuerystringParameter(this List<Parameter> parameters)
+        {
+            return parameters.GetQuerystringParameter("_method");
 		}
 	}
 }

--- a/MFaaP.MFWSClient.Tests/MFWSClient.Authentication.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSClient.Authentication.cs
@@ -24,22 +24,29 @@ namespace MFaaP.MFWSClient.Tests
 		public void AuthenticateUsingSingleSignOn()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.GET, "/WebServiceSSO.aspx?popup=1&vault=e1ce61eb-b255-41c3-b64c-faa9feb070f0");
+			var runner = new RestApiTestRunner(Method.Get, "/WebServiceSSO.aspx?popup=1&vault=e1ce61eb-b255-41c3-b64c-faa9feb070f0");
 
 			// The ASP.NET session Id (dummy value).
 			var sessionId = Guid.NewGuid().ToString();
 
 			// We need to set a base url so that we can check the session ID values.
 			runner.RestClientMock.SetupAllProperties();
-			runner.RestClientMock.SetupGet(c => c.BaseUrl)
-				.Returns(new Uri("http://example.org/"));
+            runner.RestClientMock.Setup(c => c.BaseUrl)
+                .Returns(new Uri("http://example.org/"));
+            {
+                var options = new RestClientOptions();
+                options.BaseUrl = runner.RestClientMock.Object.BaseUrl;
+                runner.RestClientMock.Setup(m => m.Options).Returns(options);
+                var cookieContainer = new CookieContainer();
+                runner.RestClientMock.Setup(m => m.CookieContainer).Returns(cookieContainer);
+            }
 
-			// Set up the response to include the session Id.
-			runner.RestClientMock
-				.Setup(c => c.ExecuteAsync(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) =>
+            // Set up the response to include the session Id.
+            runner.RestClientMock
+				.Setup(c => c.ExecuteAsync(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) =>
 				{
-					Assert.AreEqual(Method.GET, m, $"HTTP method {Method.GET} expected, but {m} was executed.");
+					Assert.AreEqual(Method.Get, r.Method, $"HTTP method {Method.Get} expected, but {r.Method} was executed.");
 
 					var vaultParameter = r.Parameters.FirstOrDefault(p => p.Type == ParameterType.QueryString && p.Name == "vault");
 					Assert.IsNotNull(vaultParameter, "Vault parameter was not found on the request.");
@@ -47,20 +54,24 @@ namespace MFaaP.MFWSClient.Tests
 				})
 				// Return a mock response.
 				.Returns(() =>
-				{
-					var response = new Mock<IRestResponse>();
-					response.SetupGet(r => r.Cookies)
-						.Returns(new List<RestResponseCookie>()
-						{
-							new RestResponseCookie() {
-								Name = "ASP.NET_SessionId",
-								Value = sessionId,
-								Path = "/",
-								Domain = "example.org"
-							}
-						});
-					return Task.FromResult(response.Object);
-				});
+                {
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse>
+                        (
+                            r => r.Cookies == new CookieCollection()
+                            {
+                                new Cookie()
+                                {
+                                    Name = "ASP.NET_SessionId",
+                                    Value = sessionId,
+                                    Path = "/",
+                                    Domain = "example.org"
+                                }
+                            }
+                        )
+                    );
+                });
 			
 			// Execute.
 			runner.MFWSClient.AuthenticateUsingSingleSignOn(Guid.Parse("e1ce61eb-b255-41c3-b64c-faa9feb070f0"));
@@ -87,22 +98,29 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AuthenticateUsingSingleSignOnAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.GET, "/WebServiceSSO.aspx?popup=1&vault=e1ce61eb-b255-41c3-b64c-faa9feb070f0");
+			var runner = new RestApiTestRunner(Method.Get, "/WebServiceSSO.aspx?popup=1&vault=e1ce61eb-b255-41c3-b64c-faa9feb070f0");
 
 			// The ASP.NET session Id (dummy value).
 			var sessionId = Guid.NewGuid().ToString();
 
 			// We need to set a base url so that we can check the session ID values.
 			runner.RestClientMock.SetupAllProperties();
-			runner.RestClientMock.SetupGet(c => c.BaseUrl)
-				.Returns(new Uri("http://example.org/"));
+            runner.RestClientMock.Setup(c => c.BaseUrl)
+                .Returns(new Uri("http://example.org/"));
+            {
+                var options = new RestClientOptions();
+                options.BaseUrl = runner.RestClientMock.Object.BaseUrl;
+                runner.RestClientMock.Setup(m => m.Options).Returns(options);
+                var cookieContainer = new CookieContainer();
+                runner.RestClientMock.Setup(m => m.CookieContainer).Returns(cookieContainer);
+            }
 
-			// Set up the response to include the session Id.
-			runner.RestClientMock
-				.Setup(c => c.ExecuteAsync(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) =>
+            // Set up the response to include the session Id.
+            runner.RestClientMock
+				.Setup(c => c.ExecuteAsync(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) =>
 				{
-					Assert.AreEqual(Method.GET, m, $"HTTP method {Method.GET} expected, but {m} was executed.");
+					Assert.AreEqual(Method.Get, r.Method, $"HTTP method {Method.Get} expected, but {r.Method} was executed.");
 
 					var vaultParameter = r.Parameters.FirstOrDefault(p => p.Type == ParameterType.QueryString && p.Name == "vault");
 					Assert.IsNotNull(vaultParameter, "Vault parameter was not found on the request.");
@@ -111,18 +129,22 @@ namespace MFaaP.MFWSClient.Tests
 				// Return a mock response.
 				.Returns(() =>
 				{
-					var response = new Mock<IRestResponse>();
-					response.SetupGet(r => r.Cookies)
-						.Returns(new List<RestResponseCookie>()
-						{
-							new RestResponseCookie() {
-								Name = "ASP.NET_SessionId",
-								Value = sessionId,
-								Path = "/",
-								Domain = "example.org"
+					return Task.FromResult
+					(
+						Mock.Of<RestResponse>
+						(
+							r => r.Cookies == new CookieCollection()
+                            {
+								new Cookie()
+								{
+									Name = "ASP.NET_SessionId",
+									Value = sessionId,
+									Path = "/",
+									Domain = "example.org"
+	                            }
 							}
-						});
-					return Task.FromResult(response.Object);
+                        )
+					);
 				});
 
 			// Execute.
@@ -154,7 +176,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task LogOutAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.DELETE, "/REST/session.aspx");
+			var runner = new RestApiTestRunner(Method.Delete, "/REST/session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.LogOutAsync();
@@ -176,7 +198,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void AuthenticateUsingCredentials()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<string>>(Method.POST, "/REST/server/authenticationtokens");
+			var runner = new RestApiTestRunner<PrimitiveType<string>>(Method.Post, "/REST/server/authenticationtokens");
 
 			// When the execute method is called, return a dummy authentication token.
 			runner.ResponseData = new PrimitiveType<string>()
@@ -218,7 +240,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AuthenticateUsingCredentialsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<string>>(Method.POST, "/REST/server/authenticationtokens");
+			var runner = new RestApiTestRunner<PrimitiveType<string>>(Method.Post, "/REST/server/authenticationtokens");
 
 			// When the execute method is called, return a dummy authentication token.
 			runner.ResponseData = new PrimitiveType<string>()
@@ -264,7 +286,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetOnlineVaults()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<Vault>>(Method.GET, "/REST/server/vaults?online=true");
+			var runner = new RestApiTestRunner<List<Vault>>(Method.Get, "/REST/server/vaults?online=true");
 
 			// Execute.
 			runner.MFWSClient.GetOnlineVaults();
@@ -282,7 +304,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetOnlineVaultsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<Vault>>(Method.GET, "/REST/server/vaults?online=true");
+			var runner = new RestApiTestRunner<List<Vault>>(Method.Get, "/REST/server/vaults?online=true");
 
 			// Execute.
 			await runner.MFWSClient.GetOnlineVaultsAsync();

--- a/MFaaP.MFWSClient.Tests/MFWSClient.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSClient.cs
@@ -20,7 +20,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetMetadataStructureIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<VaultStructureAliasResponse>(Method.POST, "/REST/structure/metadatastructure/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<VaultStructureAliasResponse>(Method.Post, "/REST/structure/metadatastructure/itemidbyalias.aspx");
 
 			// Set up the expected body.
 			var body = new VaultStructureAliasRequest();
@@ -41,7 +41,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetMetadataStructureIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<VaultStructureAliasResponse>(Method.POST, "/REST/structure/metadatastructure/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<VaultStructureAliasResponse>(Method.Post, "/REST/structure/metadatastructure/itemidbyalias.aspx");
 
 			// Set up the expected body.
 			var body = new VaultStructureAliasRequest();
@@ -89,11 +89,9 @@ namespace MFaaP.MFWSClient.Tests
 			// Ensure that we have a default parameter collection, if it's not been mocked already.
 			if (null == restClientMoq.Object.DefaultParameters)
 			{
-#pragma warning disable CS0618 // Type or member is obsolete
-				var defaultParameters = new List<Parameter>();
-#pragma warning restore CS0618 // Type or member is obsolete
-				restClientMoq
-					.SetupGet(p => p.DefaultParameters)
+                var defaultParameters = new ParametersCollection();
+                restClientMoq
+                    .SetupGet(p => p.DefaultParameters)
 					.Returns(defaultParameters);
 			}
 
@@ -113,7 +111,7 @@ namespace MFaaP.MFWSClient.Tests
 				: base(restClient)
 			{
 			}
-			protected override void OnAfterExecuteRequest(IRestResponse e)
+			protected override void OnAfterExecuteRequest(RestResponse e)
 			{
 				// If the response is null it's because we were testing for the wrong endpoint details.
 				if (null == e)

--- a/MFaaP.MFWSClient.Tests/MFWSVaultAutomaticMetadataOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultAutomaticMetadataOperations.cs
@@ -20,7 +20,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetAutomaticMetadataAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Execute.
 			await runner.MFWSClient.AutomaticMetadataOperations.GetAutomaticMetadataAsync();
@@ -37,7 +37,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetAutomaticMetadata()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Execute.
 			runner.MFWSClient.AutomaticMetadataOperations.GetAutomaticMetadata();
@@ -58,7 +58,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetAutomaticMetadataForObjectAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Set up the expected body.
 			var body = new AutomaticMetadataRequestInfo()
@@ -87,7 +87,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetAutomaticMetadataForObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Set up the expected body.
 			var body = new AutomaticMetadataRequestInfo()
@@ -120,7 +120,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetAutomaticMetadataForTemporaryFileAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Set up the expected body.
 			var body = new AutomaticMetadataRequestInfo()
@@ -144,7 +144,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetAutomaticMetadataForTemporaryFile()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Set up the expected body.
 			var body = new AutomaticMetadataRequestInfo()
@@ -168,7 +168,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetAutomaticMetadataForTemporaryFilesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Set up the expected body.
 			var body = new AutomaticMetadataRequestInfo()
@@ -193,7 +193,7 @@ namespace MFaaP.MFWSClient.Tests
 		{
 			// Create our test runner.
 			var runner =
-				new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.POST, "/REST/objects/automaticmetadata.aspx");
+				new RestApiTestRunner<List<PropertyValueSuggestion>>(Method.Post, "/REST/objects/automaticmetadata.aspx");
 
 			// Set up the expected body.
 			var body = new AutomaticMetadataRequestInfo()

--- a/MFaaP.MFWSClient.Tests/MFWSVaultClassGroupOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultClassGroupOperations.cs
@@ -19,7 +19,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetClassGroupsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
+			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.Get, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
 
 			// Execute.
 			await runner.MFWSClient.ClassGroupOperations.GetClassGroupsAsync(0);
@@ -36,7 +36,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetClassGroups()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.GET, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
+			var runner = new RestApiTestRunner<List<ClassGroup>>(Method.Get, "/REST/structure/classes.aspx?objtype=0&bygroup=true");
 
 			// Execute.
 			runner.MFWSClient.ClassGroupOperations.GetClassGroups(0);

--- a/MFaaP.MFWSClient.Tests/MFWSVaultClassOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultClassOperations.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 
 namespace MFaaP.MFWSClient.Tests
@@ -19,10 +20,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectClassIDByAliasAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/classes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/classes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -40,10 +41,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectClassIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/classes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/classes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -61,10 +62,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectClassIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/classes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/classes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -82,10 +83,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectClassIDByAlias()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/classes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/classes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -107,7 +108,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetAllObjectClassesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.GET, "/REST/structure/classes.aspx");
+			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.Get, "/REST/structure/classes.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ClassOperations.GetAllObjectClassesAsync();
@@ -124,7 +125,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetAllObjectClasses()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.GET, "/REST/structure/classes.aspx");
+			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.Get, "/REST/structure/classes.aspx");
 
 			// Execute.
 			runner.MFWSClient.ClassOperations.GetAllObjectClasses();
@@ -145,7 +146,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectClassesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.GET, "/REST/structure/classes.aspx?objtype=0");
+			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.Get, "/REST/structure/classes.aspx?objtype=0");
 
 			// Execute.
 			await runner.MFWSClient.ClassOperations.GetObjectClassesAsync(0);
@@ -162,7 +163,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectClasses()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.GET, "/REST/structure/classes.aspx?objtype=0");
+			var runner = new RestApiTestRunner<List<ExtendedObjectClass>>(Method.Get, "/REST/structure/classes.aspx?objtype=0");
 
 			// Execute.
 			runner.MFWSClient.ClassOperations.GetObjectClasses(0);
@@ -183,7 +184,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectClassAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.GET, "/REST/structure/classes/0.aspx");
+			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.Get, "/REST/structure/classes/0.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ClassOperations.GetObjectClassAsync(classId: 0);
@@ -200,7 +201,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectClass()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.GET, "/REST/structure/classes/0.aspx");
+			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.Get, "/REST/structure/classes/0.aspx");
 
 			// Execute.
 			runner.MFWSClient.ClassOperations.GetObjectClass(classId: 0);
@@ -221,7 +222,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectClassAsync_WithTemplates()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.GET, "/REST/structure/classes/0.aspx?include=templates");
+			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.Get, "/REST/structure/classes/0.aspx?include=templates");
 
 			// Execute.
 			await runner.MFWSClient.ClassOperations.GetObjectClassAsync(classId: 0, includeTemplates: true);
@@ -238,7 +239,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectClass_WithTemplates()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.GET, "/REST/structure/classes/0.aspx?include=templates");
+			var runner = new RestApiTestRunner<ExtendedObjectClass>(Method.Get, "/REST/structure/classes/0.aspx?include=templates");
 
 			// Execute.
 			runner.MFWSClient.ClassOperations.GetObjectClass(classId: 0, includeTemplates: true);

--- a/MFaaP.MFWSClient.Tests/MFWSVaultExtensionAuthenticationOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultExtensionAuthenticationOperations.cs
@@ -21,7 +21,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetExtensionAuthenticationTargetsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<RepositoryAuthenticationTarget>>(Method.GET, "/REST/repositories.aspx");
+			var runner = new RestApiTestRunner<List<RepositoryAuthenticationTarget>>(Method.Get, "/REST/repositories.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.GetExtensionAuthenticationTargetsAsync();
@@ -38,7 +38,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetExtensionAuthenticationTargets()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<RepositoryAuthenticationTarget>>(Method.GET, "/REST/repositories.aspx");
+			var runner = new RestApiTestRunner<List<RepositoryAuthenticationTarget>>(Method.Get, "/REST/repositories.aspx");
 
 			// Execute.
 			runner.MFWSClient.ExtensionAuthenticationOperations.GetExtensionAuthenticationTargets();
@@ -62,7 +62,7 @@ namespace MFaaP.MFWSClient.Tests
 			var targetID = "hello world";
 
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
 
 			// Create the body.
 			var authentication = new RepositoryAuthentication()
@@ -89,7 +89,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task LogInWithExtensionAuthenticationAsync_NullTarget()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories//session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories//session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.LogInWithExtensionAuthenticationAsync(null, new RepositoryAuthentication());
@@ -106,7 +106,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task LogInWithExtensionAuthenticationAsync_EmptyTarget()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories//session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories//session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.LogInWithExtensionAuthenticationAsync("", new RepositoryAuthentication());
@@ -123,7 +123,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task LogInWithExtensionAuthenticationAsync_NullAuthentication()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories//session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories//session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.LogInWithExtensionAuthenticationAsync("hello world", null);
@@ -140,7 +140,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task LogInWithExtensionAuthenticationAsync_EmptyAuthenticationConfiguration()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories//session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories//session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.LogInWithExtensionAuthenticationAsync("hello world", new RepositoryAuthentication());
@@ -159,7 +159,7 @@ namespace MFaaP.MFWSClient.Tests
 			var targetID = "hello world";
 
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
 
 			// Create the body.
 			var authentication = new RepositoryAuthentication()
@@ -192,7 +192,7 @@ namespace MFaaP.MFWSClient.Tests
 			var targetID = "hello world";
 
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.DELETE, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
+			var runner = new RestApiTestRunner(Method.Delete, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.LogOutWithExtensionAuthenticationAsync(targetID);
@@ -210,7 +210,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task LogOutWithExtensionAuthenticationAsync_NullTarget()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories//session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories//session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.LogOutWithExtensionAuthenticationAsync(null);
@@ -227,7 +227,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task LogOutWithExtensionAuthenticationAsync_EmptyTarget()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.POST, $"/REST/repositories//session.aspx");
+			var runner = new RestApiTestRunner<RepositoryAuthenticationStatus>(Method.Post, $"/REST/repositories//session.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionAuthenticationOperations.LogOutWithExtensionAuthenticationAsync("");
@@ -246,7 +246,7 @@ namespace MFaaP.MFWSClient.Tests
 			var targetID = "hello world";
 
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.DELETE, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
+			var runner = new RestApiTestRunner(Method.Delete, $"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
 
 			// Execute.
 			runner.MFWSClient.ExtensionAuthenticationOperations.LogOutWithExtensionAuthentication(targetID);

--- a/MFaaP.MFWSClient.Tests/MFWSVaultExtensionMethodOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultExtensionMethodOperations.cs
@@ -20,7 +20,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ExecuteExtensionMethodAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ExtensionMethodOperations.ExecuteVaultExtensionMethodAsync("HelloWorld");
@@ -37,7 +37,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ExecuteExtensionMethod()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Execute.
 			runner.MFWSClient.ExtensionMethodOperations.ExecuteVaultExtensionMethod("HelloWorld");
@@ -54,7 +54,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ExecuteExtensionMethodAsync_CorrectRequestBody()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			const string inputValue = "this is my test input value";
@@ -75,7 +75,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ExecuteExtensionMethod_CorrectRequestBody()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			const string inputValue = "this is my test input value";
@@ -96,7 +96,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ExecuteExtensionMethodAsync_CorrectOutput()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			const string inputValue = "this is my test input value";
@@ -124,7 +124,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ExecuteExtensionMethod_CorrectOutput()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			const string inputValue = "this is my test input value";
@@ -156,7 +156,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ExecuteExtensionMethodAsync_InputSerialisation()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			var inputValue = new MySerialisableObject
@@ -188,7 +188,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ExecuteExtensionMethod_InputSerialisation()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			var inputValue = new MySerialisableObject
@@ -224,7 +224,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ExecuteExtensionMethodAsync_OutputDeserialisation()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<MySerialisableObject>(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner<MySerialisableObject>(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			var inputValue = new MySerialisableObject
@@ -262,7 +262,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ExecuteExtensionMethod_OutputDeserialisation()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<MySerialisableObject>(Method.POST, "/REST/vault/extensionmethod/HelloWorld.aspx");
+			var runner = new RestApiTestRunner<MySerialisableObject>(Method.Post, "/REST/vault/extensionmethod/HelloWorld.aspx");
 
 			// Set the request body.
 			var inputValue = new MySerialisableObject
@@ -296,8 +296,8 @@ namespace MFaaP.MFWSClient.Tests
 
 		public class MySerialisableObject
 		{
-			public string a = "b";
-			public int x = 7;
+			public string a { get; set; } = "b";
+			public int x { get; set; } = 7;
 
 			public string ToSerializedString()
 			{

--- a/MFaaP.MFWSClient.Tests/MFWSVaultExternalObjectOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultExternalObjectOperations.cs
@@ -22,7 +22,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task DemoteObjectAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/demotemultiobjects");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/demotemultiobjects");
 
 			// Create the expected body.
 			var body = new[]
@@ -52,7 +52,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void DemoteObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/demotemultiobjects");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/demotemultiobjects");
 
 			// Create the expected body.
 			var body = new[]
@@ -86,7 +86,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task DemoteObjectsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/demotemultiobjects");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/demotemultiobjects");
 
 			// Create the expected body.
 			var body = new[]
@@ -121,7 +121,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void DemoteObjects()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/demotemultiobjects");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/demotemultiobjects");
 
 			// Create the expected body.
 			var body = new[]
@@ -164,7 +164,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task PromoteObjectAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/setmultipleobjproperties");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/setmultipleobjproperties");
 
 			// Create the expected body.
 			var body = new ObjectsUpdateInfo()
@@ -231,7 +231,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void PromoteObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/setmultipleobjproperties");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/setmultipleobjproperties");
 
 			// Create the expected body.
 			var body = new ObjectsUpdateInfo()
@@ -302,7 +302,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task PromoteObjectsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/setmultipleobjproperties");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/setmultipleobjproperties");
 
 			// Create the expected body.
 			var body = new ObjectsUpdateInfo()
@@ -379,7 +379,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void PromoteObjects()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/setmultipleobjproperties");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/setmultipleobjproperties");
 
 			// Create the expected body.
 			var body = new ObjectsUpdateInfo()

--- a/MFaaP.MFWSClient.Tests/MFWSVaultObjectFileOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultObjectFileOperations.cs
@@ -26,13 +26,13 @@ namespace MFaaP.MFWSClient.Tests
             {
             }
 
-            public List<FileParameter> RequestFiles { get; private set; }
+            public IReadOnlyCollection<FileParameter> RequestFiles { get; private set; }
                 = new List<FileParameter>();
 
             #region Overrides of RestApiTestRunner
 
             /// <inheritdoc />
-            protected override void HandleCallback(IRestRequest r)
+            protected override void HandleCallback(RestRequest r)
             {
                 this.RequestFiles = r?.Files;
                 base.HandleCallback(r);
@@ -51,7 +51,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task UploadFileAsync()
         {
             // Create our test runner.
-            var runner = new FileRestApiTestRunner<ExtendedObjectVersion>(Method.PUT, "/REST/objects/456/123/9/files/123/content.aspx");
+            var runner = new FileRestApiTestRunner<ExtendedObjectVersion>(Method.Put, "/REST/objects/456/123/9/files/123/content.aspx");
 
             // Create a temporary file.
             var tempFile = new FileInfo(@"test.txt");
@@ -81,8 +81,8 @@ namespace MFaaP.MFWSClient.Tests
             // Ensure the file data was passed.
             Assert.IsNotNull(runner.RequestFiles);
             Assert.AreEqual(1, runner.RequestFiles.Count);
-            Assert.AreEqual(tempFile.Name, runner.RequestFiles[0].Name);
-            Assert.AreEqual(tempFile.Length, runner.RequestFiles[0].ContentLength);
+            Assert.AreEqual(tempFile.Name, runner.RequestFiles.ElementAt(0).Name);
+            Assert.AreEqual(tempFile.Length, runner.RequestFiles.ElementAt(0).GetFile().Length);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task UploadFileAsync_Latest()
         {
             // Create our test runner.
-            var runner = new FileRestApiTestRunner<ExtendedObjectVersion>(Method.PUT, "/REST/objects/456/123/latest/files/123/content.aspx");
+            var runner = new FileRestApiTestRunner<ExtendedObjectVersion>(Method.Put, "/REST/objects/456/123/latest/files/123/content.aspx");
 
             // Create a temporary file.
             var tempFile = new FileInfo(@"test.txt");
@@ -122,8 +122,8 @@ namespace MFaaP.MFWSClient.Tests
             // Ensure the file data was passed.
             Assert.IsNotNull(runner.RequestFiles);
             Assert.AreEqual(1, runner.RequestFiles.Count);
-            Assert.AreEqual(tempFile.Name, runner.RequestFiles[0].Name);
-            Assert.AreEqual(tempFile.Length, runner.RequestFiles[0].ContentLength);
+            Assert.AreEqual(tempFile.Name, runner.RequestFiles.ElementAt(0).Name);
+            Assert.AreEqual(tempFile.Length, runner.RequestFiles.ElementAt(0).GetFile().Length);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task UploadFileAsync_Unmanaged()
         {
             // Create our test runner.
-            var runner = new FileRestApiTestRunner<ExtendedObjectVersion>(Method.PUT, "/REST/objects/0/umy%2Brepository%3Amy%2Bobject/uversion%2B1/files/umy%2Bfile/content.aspx");
+            var runner = new FileRestApiTestRunner<ExtendedObjectVersion>(Method.Put, "/REST/objects/0/umy%2Brepository%3Amy%2Bobject/uversion%2B1/files/umy%2Bfile/content.aspx");
 
             // Create a temporary file.
             var tempFile = new FileInfo(@"test.txt");
@@ -166,8 +166,8 @@ namespace MFaaP.MFWSClient.Tests
             // Ensure the file data was passed.
             Assert.IsNotNull(runner.RequestFiles);
             Assert.AreEqual(1, runner.RequestFiles.Count);
-            Assert.AreEqual(tempFile.Name, runner.RequestFiles[0].Name);
-            Assert.AreEqual(tempFile.Length, runner.RequestFiles[0].ContentLength);
+            Assert.AreEqual(tempFile.Name, runner.RequestFiles.ElementAt(0).Name);
+            Assert.AreEqual(tempFile.Length, runner.RequestFiles.ElementAt(0).GetFile().Length);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task UploadFilesAsync()
         {
             // Create our test runner.
-            var runner = new FileRestApiTestRunner<List<UploadInfo>>(Method.POST, "/REST/files.aspx");
+            var runner = new FileRestApiTestRunner<List<UploadInfo>>(Method.Post, "/REST/files.aspx");
 
             // Create a temporary file.
             var tempFile = new FileInfo(@"test.txt");
@@ -209,8 +209,8 @@ namespace MFaaP.MFWSClient.Tests
             // Ensure the file data was passed.
             Assert.IsNotNull(runner.RequestFiles);
             Assert.AreEqual(1, runner.RequestFiles.Count);
-            Assert.AreEqual(tempFile.Name, runner.RequestFiles[0].Name);
-            Assert.AreEqual(tempFile.Length, runner.RequestFiles[0].ContentLength);
+            Assert.AreEqual(tempFile.Name, runner.RequestFiles.ElementAt(0).Name);
+            Assert.AreEqual(tempFile.Length, runner.RequestFiles.ElementAt(0).GetFile().Length);
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace MFaaP.MFWSClient.Tests
         public void UploadFiles()
         {
             // Create our test runner.
-            var runner = new FileRestApiTestRunner<List<UploadInfo>>(Method.POST, "/REST/files.aspx");
+            var runner = new FileRestApiTestRunner<List<UploadInfo>>(Method.Post, "/REST/files.aspx");
 
             // Create a temporary file.
             var tempFile = new FileInfo(@"test.txt");
@@ -252,8 +252,8 @@ namespace MFaaP.MFWSClient.Tests
             // Ensure the file data was passed.
             Assert.IsNotNull(runner.RequestFiles);
             Assert.AreEqual(1, runner.RequestFiles.Count);
-            Assert.AreEqual(tempFile.Name, runner.RequestFiles[0].Name);
-            Assert.AreEqual(tempFile.Length, runner.RequestFiles[0].ContentLength);
+            Assert.AreEqual(tempFile.Name, runner.RequestFiles.ElementAt(0).Name);
+            Assert.AreEqual(tempFile.Length, runner.RequestFiles.ElementAt(0).GetFile().Length);
         }
 
         #endregion
@@ -268,7 +268,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task DownloadFileAsync()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner(Method.GET, "/REST/objects/1/2/4/files/3/content");
+            var runner = new RestApiTestRunner(Method.Get, "/REST/objects/1/2/4/files/3/content");
 
             // Execute.
             await runner.MFWSClient.ObjectFileOperations.DownloadFileAsync(1, 2, 3, 4);
@@ -285,7 +285,7 @@ namespace MFaaP.MFWSClient.Tests
         public void DownloadFile()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner(Method.GET, "/REST/objects/1/2/4/files/3/content");
+            var runner = new RestApiTestRunner(Method.Get, "/REST/objects/1/2/4/files/3/content");
 
             // Execute.
             runner.MFWSClient.ObjectFileOperations.DownloadFile(1, 2, 3, 4);
@@ -303,7 +303,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task DownloadFileAsync_Umanaged()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner(Method.GET, "/REST/objects/0/umy%2Brepository%3Amy%2Bobject/uversion%2B1/files/umy%2Bfile/content");
+            var runner = new RestApiTestRunner(Method.Get, "/REST/objects/0/umy%2Brepository%3Amy%2Bobject/uversion%2B1/files/umy%2Bfile/content");
 
             // Execute.
             await runner.MFWSClient.ObjectFileOperations.DownloadFileAsync(new ObjVer()
@@ -330,7 +330,7 @@ namespace MFaaP.MFWSClient.Tests
         public void DownloadFile_Unmanaged()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner(Method.GET, "/REST/objects/0/umy%2Brepository%3Amy%2Bobject/uversion%2B1/files/umy%2Bfile/content");
+            var runner = new RestApiTestRunner(Method.Get, "/REST/objects/0/umy%2Brepository%3Amy%2Bobject/uversion%2B1/files/umy%2Bfile/content");
 
             // Execute.
             runner.MFWSClient.ObjectFileOperations.DownloadFile(new ObjVer()
@@ -374,8 +374,8 @@ namespace MFaaP.MFWSClient.Tests
 
             // When the execute method is called, log the resource requested.
             mock
-                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-                .Callback((IRestRequest r, Method m, CancellationToken t) =>
+                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .Callback((RestRequest r, CancellationToken t) =>
                 {
                     resourceAddress = r.Resource;
                 })
@@ -383,37 +383,35 @@ namespace MFaaP.MFWSClient.Tests
                 .Returns(() =>
                 {
                     // Create the mock response.
-                    var response = new Mock<IRestResponse<ExtendedObjectVersion>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new ExtendedObjectVersion());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<ExtendedObjectVersion>>
+                        (
+                            m => m.Data == new ExtendedObjectVersion()
+                        )
+                    );
                 });
 
             // We also need to handle the upload file call or our tests will except.
             mock
-                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<RestRequest>(),  It.IsAny<CancellationToken>()))
                 // Return a mock response.
                 .Returns(() =>
                 {
                     // Create the mock response.
-                    var response = new Mock<IRestResponse<List<UploadInfo>>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new[]
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<UploadInfo>>>
+                        (
+                            m => m.Data == new[]
                         {
                             new UploadInfo()
                             {
                                 UploadID = 1
                             }
-                        }.ToList());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                        }.ToList()
+                        )
+                    );
                 });
 
             /* Act */
@@ -427,7 +425,7 @@ namespace MFaaP.MFWSClient.Tests
             /* Assert */
 
             // Execute must be called once.
-            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
             // Resource must be correct.
             Assert.AreEqual("/REST/objects/0/1/2/files/upload", resourceAddress);
@@ -455,46 +453,43 @@ namespace MFaaP.MFWSClient.Tests
 
             // When the execute method is called, log the resource requested.
             mock
-                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-                .Callback((IRestRequest r, Method m, CancellationToken t) =>
+                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .Callback((RestRequest r, CancellationToken t) =>
                 {
                     resourceAddress = r.Resource;
                 })
                 // Return a mock response.
                 .Returns(() =>
                 {
-                    // Create the mock response.
-                    var response = new Mock<IRestResponse<ExtendedObjectVersion>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new ExtendedObjectVersion());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<ExtendedObjectVersion>>
+                        (
+                            m => m.Data == new ExtendedObjectVersion()
+                        )
+                    );
                 });
 
             // We also need to handle the upload file call or our tests will except.
             mock
-                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
                 // Return a mock response.
                 .Returns(() =>
                 {
                     // Create the mock response.
-                    var response = new Mock<IRestResponse<List<UploadInfo>>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new[]
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<UploadInfo>>>
+                        (
+                            m => m.Data == new[]
                         {
                             new UploadInfo()
                             {
                                 UploadID = 1
                             }
-                        }.ToList());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                        }.ToList()
+                        )
+                    );
                 });
 
 
@@ -509,7 +504,7 @@ namespace MFaaP.MFWSClient.Tests
             /* Assert */
 
             // Execute must be called once.
-            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
             // Resource must be correct.
             Assert.AreEqual("/REST/objects/0/1/2/files/upload", resourceAddress);
@@ -540,8 +535,8 @@ namespace MFaaP.MFWSClient.Tests
 
             // When the execute method is called, log the resource requested.
             mock
-                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-                .Callback((IRestRequest r, Method m, CancellationToken t) =>
+                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .Callback((RestRequest r, CancellationToken t) =>
                 {
                     methodUsed = r.Method;
                 })
@@ -549,37 +544,35 @@ namespace MFaaP.MFWSClient.Tests
                 .Returns(() =>
                 {
                     // Create the mock response.
-                    var response = new Mock<IRestResponse<ExtendedObjectVersion>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new ExtendedObjectVersion());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<ExtendedObjectVersion>>
+                        (
+                            m => m.Data == new ExtendedObjectVersion()
+                        )
+                    );
                 });
 
             // We also need to handle the upload file call or our tests will except.
             mock
-                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
                 // Return a mock response.
                 .Returns(() =>
                 {
                     // Create the mock response.
-                    var response = new Mock<IRestResponse<List<UploadInfo>>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new[]
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<UploadInfo>>>
+                        (
+                            m => m.Data == new[]
                         {
                             new UploadInfo()
                             {
                                 UploadID = 1
                             }
-                        }.ToList());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                        }.ToList()
+                        )
+                    );
                 });
 
             /* Act */
@@ -593,10 +586,10 @@ namespace MFaaP.MFWSClient.Tests
             /* Assert */
 
             // Execute must be called once.
-            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
             // Method must be correct.
-            Assert.AreEqual(Method.POST, methodUsed);
+            Assert.AreEqual(Method.Post, methodUsed);
         }
 
         /// <summary>
@@ -621,46 +614,44 @@ namespace MFaaP.MFWSClient.Tests
 
             // When the execute method is called, log the resource requested.
             mock
-                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-                .Callback((IRestRequest r, Method m, CancellationToken t) =>
+                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .Callback((RestRequest r, CancellationToken t) =>
                 {
                     methodUsed = r.Method;
                 })
                 // Return a mock response.
                 .Returns(() =>
                 {
-                    // Create the mock response.
-                    var response = new Mock<IRestResponse<ExtendedObjectVersion>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new ExtendedObjectVersion());
-
                     //Return the mock object.
-                    return Task.FromResult(response.Object);
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<ExtendedObjectVersion>>
+                        (
+                            m => m.Data == new ExtendedObjectVersion()
+                        )
+                    );
                 });
 
             // We also need to handle the upload file call or our tests will except.
             mock
-                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.ExecuteAsync<List<UploadInfo>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
                 // Return a mock response.
                 .Returns(() =>
                 {
-                    // Create the mock response.
-                    var response = new Mock<IRestResponse<List<UploadInfo>>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new[]
+                    //Return the mock object.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<UploadInfo>>>
+                        (
+                            m => m.Data == new[]
                         {
                             new UploadInfo()
                             {
                                 UploadID = 1
                             }
-                        }.ToList());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                        }.ToList()
+                        )
+                    );
                 });
 
             /* Act */
@@ -674,10 +665,10 @@ namespace MFaaP.MFWSClient.Tests
             /* Assert */
 
             // Execute must be called once.
-            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
             // Method must be correct.
-            Assert.AreEqual(Method.POST, methodUsed);
+            Assert.AreEqual(Method.Post, methodUsed);
         }
 
         #endregion
@@ -692,7 +683,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task RenameFileAsync()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/1/2/latest/files/3/latest/title");
+            var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/1/2/latest/files/3/latest/title");
 
             // Create the object to send in the body.
             var body = new PrimitiveType<string>()
@@ -718,7 +709,7 @@ namespace MFaaP.MFWSClient.Tests
         public async Task RenameFileAsync_WithVersionData()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/1/2/4/files/3/5/title");
+            var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/1/2/4/files/3/5/title");
 
             // Create the object to send in the body.
             var body = new PrimitiveType<string>()
@@ -744,7 +735,7 @@ namespace MFaaP.MFWSClient.Tests
         public void RenameFile()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/4/5/latest/files/6/latest/title");
+            var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/4/5/latest/files/6/latest/title");
 
             // Create the object to send in the body.
             var body = new PrimitiveType<string>()
@@ -770,7 +761,7 @@ namespace MFaaP.MFWSClient.Tests
         public void RenameFileWithVersionData()
         {
             // Create our test runner.
-            var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/4/5/7/files/6/8/title");
+            var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/4/5/7/files/6/8/title");
 
             // Create the object to send in the body.
             var body = new PrimitiveType<string>()
@@ -802,8 +793,8 @@ namespace MFaaP.MFWSClient.Tests
 
             // When the execute method is called, log the resource requested.
             mock
-                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-                .Callback((IRestRequest r, Method m, CancellationToken t) =>
+                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .Callback((RestRequest r, CancellationToken t) =>
                 {
                     resourceAddress = r.Resource;
                 })
@@ -811,14 +802,13 @@ namespace MFaaP.MFWSClient.Tests
                 .Returns(() =>
                 {
                     // Create the mock response.
-                    var response = new Mock<IRestResponse<ExtendedObjectVersion>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new ExtendedObjectVersion());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<ExtendedObjectVersion>>
+                        (
+                            m => m.Data == new ExtendedObjectVersion()
+                        )
+                    );
                 });
 
 
@@ -837,7 +827,7 @@ namespace MFaaP.MFWSClient.Tests
             });
 
             // Execute must be called once.
-            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
             // Resource must be correct.
             Assert.AreEqual("/REST/objects/0/1/2/files/3", resourceAddress);
@@ -854,8 +844,8 @@ namespace MFaaP.MFWSClient.Tests
 
             // When the execute method is called, log the resource requested.
             mock
-                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-                .Callback((IRestRequest r, Method m, CancellationToken t) =>
+                .Setup(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+                .Callback((RestRequest r, CancellationToken t) =>
                  {
                      resourceAddress = r.Resource;
                  })
@@ -863,14 +853,13 @@ namespace MFaaP.MFWSClient.Tests
                 .Returns(() =>
                 {
                     // Create the mock response.
-                    var response = new Mock<IRestResponse<ExtendedObjectVersion>>();
-
-                    // Setup the return data.
-                    response.SetupGet(r => r.Data)
-                        .Returns(new ExtendedObjectVersion());
-
-                    //Return the mock object.
-                    return Task.FromResult(response.Object);
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<ExtendedObjectVersion>>
+                        (
+                            m => m.Data == new ExtendedObjectVersion()
+                        )
+                    );
                 });
 
 
@@ -888,7 +877,7 @@ namespace MFaaP.MFWSClient.Tests
             });
 
             // Execute must be called once.
-            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+            mock.Verify(c => c.ExecuteAsync<ExtendedObjectVersion>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
             // Resource must be correct.
             Assert.AreEqual("/REST/objects/0/1/2/files/3", resourceAddress);

--- a/MFaaP.MFWSClient.Tests/MFWSVaultObjectOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultObjectOperations.cs
@@ -25,7 +25,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task RenameObjectAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/1/2/latest/title");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/1/2/latest/title");
 
 			// Set the expected body.
 			var newObjectName = new PrimitiveType<string>()
@@ -54,7 +54,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task RenameObjectAsync_Unmanaged()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/uhello%3Aworld/uagain/title");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/uhello%3Aworld/uagain/title");
 
 			// Set the expected body.
 			var newObjectName = new PrimitiveType<string>()
@@ -85,7 +85,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task RenameObjectAsync_Unmanaged_Latest()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/uhello%3Aworld/latest/title");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/uhello%3Aworld/latest/title");
 
 			// Set the expected body.
 			var newObjectName = new PrimitiveType<string>()
@@ -114,7 +114,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void RenameObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/1/2/latest/title");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/1/2/latest/title");
 
 			// Set the expected body.
 			var newObjectName = new PrimitiveType<string>()
@@ -146,7 +146,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetLatestObjectVersionAndPropertiesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.GET, "/REST/objects/0/123/latest.aspx?include=properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Get, "/REST/objects/0/123/latest.aspx?include=properties");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.GetLatestObjectVersionAndPropertiesAsync(0, 123);
@@ -163,7 +163,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetLatestObjectVersionAndProperties()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.GET, "/REST/objects/0/123/latest.aspx?include=properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Get, "/REST/objects/0/123/latest.aspx?include=properties");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.GetLatestObjectVersionAndProperties(0, 123);
@@ -181,7 +181,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetLatestObjectVersionAndPropertiesAsync_External()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.GET, "/REST/objects/0/uhello%2Bworld%3A123%2525123/latest.aspx?include=properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Get, "/REST/objects/0/uhello%2Bworld%3A123%2525123/latest.aspx?include=properties");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.GetLatestObjectVersionAndPropertiesAsync(new ObjID()
@@ -204,7 +204,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetLatestObjectVersionAndProperties_External()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.GET, "/REST/objects/0/uhello%2Bworld%3A123%2525123/latest.aspx?include=properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Get, "/REST/objects/0/uhello%2Bworld%3A123%2525123/latest.aspx?include=properties");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.GetLatestObjectVersionAndProperties(new ObjID()
@@ -230,7 +230,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task CreateNewObjectAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.POST, $"/REST/objects/0");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Post, $"/REST/objects/0");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.CreateNewObjectAsync(0, new ObjectCreationInfo());
@@ -247,7 +247,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void CreateNewObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.POST, $"/REST/objects/0");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Post, $"/REST/objects/0");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.CreateNewObject(0, new ObjectCreationInfo());
@@ -268,7 +268,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetCheckoutStatusAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.GET, $"/REST/objects/0/1/2/checkedout");
+			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.Get, $"/REST/objects/0/1/2/checkedout");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.GetCheckoutStatusAsync(new ObjVer()
@@ -290,7 +290,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetCheckoutStatus()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.GET, $"/REST/objects/0/1/2/checkedout");
+			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.Get, $"/REST/objects/0/1/2/checkedout");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.GetCheckoutStatus(new ObjVer()
@@ -313,7 +313,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetCheckoutStatusAsync_External()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.GET, $"/REST/objects/0/umy+repository:hello+world/latest/checkedout");
+			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.Get, $"/REST/objects/0/umy+repository:hello+world/latest/checkedout");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.GetCheckoutStatusAsync(new ObjVer()
@@ -336,7 +336,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetCheckoutStatus_External()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.GET, $"/REST/objects/0/umy+repository:hello+world/latest/checkedout");
+			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.Get, $"/REST/objects/0/umy+repository:hello+world/latest/checkedout");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.GetCheckoutStatus(new ObjVer()
@@ -359,7 +359,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetCheckoutStatusAsync_External_WithVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.GET, $"/REST/objects/0/umy+repository:hello+world/myversionid/checkedout");
+			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.Get, $"/REST/objects/0/umy+repository:hello+world/myversionid/checkedout");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.GetCheckoutStatusAsync(new ObjVer()
@@ -383,7 +383,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetCheckoutStatus_External_WithVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.GET, $"/REST/objects/0/umy+repository:hello+world/myversionid/checkedout");
+			var runner = new RestApiTestRunner<PrimitiveType<MFCheckOutStatus>>(Method.Get, $"/REST/objects/0/umy+repository:hello+world/myversionid/checkedout");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.GetCheckoutStatus(new ObjVer()
@@ -410,7 +410,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void UndoCheckout()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.DELETE, $"/REST/objects/0/1/2?force=false");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Delete, $"/REST/objects/0/1/2?force=false");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.UndoCheckout(0, 1, 2);
@@ -427,7 +427,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ForceUndoCheckout()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.DELETE, $"/REST/objects/0/1/2?force=true");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Delete, $"/REST/objects/0/1/2?force=true");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.ForceUndoCheckout(0, 1, 2);
@@ -448,7 +448,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void UndeleteObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/deleted");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/deleted");
 
 			// Set the expected request body.
 			runner.SetExpectedRequestBody(new PrimitiveType<bool>()
@@ -475,7 +475,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void DeleteObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/deleted");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/deleted");
 
 			// Set the expected request body.
 			runner.SetExpectedRequestBody(new PrimitiveType<bool>()
@@ -502,7 +502,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void DestroyObject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.DELETE, $"/REST/objects/0/1/latest?allVersions=true");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Delete, $"/REST/objects/0/1/latest?allVersions=true");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.DestroyObject(0, 1, true, -1);
@@ -523,7 +523,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SetCheckoutStatusAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/2/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -548,7 +548,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetCheckoutStatus()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/2/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -574,7 +574,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SetCheckoutStatusAsync_External()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/urepository%2Bname%3Amy%2Bobject/uversion%2B1/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/urepository%2Bname%3Amy%2Bobject/uversion%2B1/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -601,7 +601,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetCheckoutStatus_External()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/urepository%2Bname%3Amy%2Bobject/uversion%2B1/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/urepository%2Bname%3Amy%2Bobject/uversion%2B1/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -628,7 +628,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetCheckoutStatus_External_Latest()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/urepository%2Bname%3Amy%2Bobject/latest/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/urepository%2Bname%3Amy%2Bobject/latest/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -654,7 +654,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SetCheckoutStatusAsync_LatestVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/latest/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/latest/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -679,7 +679,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetCheckoutStatus_LatestVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/latest/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/latest/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -704,7 +704,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetCheckoutStatus_CheckIn()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/latest/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/latest/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedIn });
@@ -729,7 +729,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetCheckoutStatus_CheckedOutToMe()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, $"/REST/objects/0/1/latest/checkedout");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, $"/REST/objects/0/1/latest/checkedout");
 
 			// Set the expected body.
 			runner.SetExpectedRequestBody(new PrimitiveType<MFCheckOutStatus>() { Value = MFCheckOutStatus.CheckedOutToMe });
@@ -757,7 +757,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetHistoryAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ObjectVersion>>(Method.GET, $"/REST/objects/0/1/history");
+			var runner = new RestApiTestRunner<List<ObjectVersion>>(Method.Get, $"/REST/objects/0/1/history");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.GetHistoryAsync(new ObjID()
@@ -778,7 +778,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetHistory()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ObjectVersion>>(Method.GET, $"/REST/objects/0/1/history");
+			var runner = new RestApiTestRunner<List<ObjectVersion>>(Method.Get, $"/REST/objects/0/1/history");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.GetHistory(new ObjID()
@@ -803,7 +803,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task RemoveFromFavoritesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.DELETE, $"/REST/favorites/1/2");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Delete, $"/REST/favorites/1/2");
 
 			// Execute.
 			await runner.MFWSClient.ObjectOperations.RemoveFromFavoritesAsync(new ObjID()
@@ -824,7 +824,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void RemoveFromFavorites()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.DELETE, $"/REST/favorites/1/2");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Delete, $"/REST/favorites/1/2");
 
 			// Execute.
 			runner.MFWSClient.ObjectOperations.RemoveFromFavorites(new ObjID()
@@ -849,7 +849,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AddToFavoritesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.POST, $"/REST/favorites");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Post, $"/REST/favorites");
 
 			// Set the expected body.
 			var objId = new ObjID()
@@ -874,7 +874,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void AddToFavorites()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.POST, $"/REST/favorites");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Post, $"/REST/favorites");
 
 			// Set the expected body.
 			var objId = new ObjID()

--- a/MFaaP.MFWSClient.Tests/MFWSVaultObjectPropertyOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultObjectPropertyOperations.cs
@@ -21,7 +21,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertiesAsync_ExternalObject_LatestVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.GET, $"/REST/objects/0/umyrepository%3A12%2B3456/latest/properties.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.Get, $"/REST/objects/0/umyrepository%3A12%2B3456/latest/properties.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.GetPropertiesAsync(new ObjVer()
@@ -44,7 +44,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertiesAsync_ExternalObject_SpecificVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.GET, $"/REST/objects/0/umyrepository%3A12%2B3456/uabc%253A123/properties.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.Get, $"/REST/objects/0/umyrepository%3A12%2B3456/uabc%253A123/properties.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.GetPropertiesAsync(new ObjVer()
@@ -73,7 +73,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetProperties_ObjVer()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.GET, "/REST/objects/1/2/4/properties.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.Get, "/REST/objects/1/2/4/properties.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.GetProperties(1, 2, 4);
@@ -91,7 +91,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertiesAsync_ObjVer()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.GET, "/REST/objects/1/2/4/properties.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.Get, "/REST/objects/1/2/4/properties.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.GetPropertiesAsync(1, 2, 4);
@@ -109,7 +109,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetProperties_ObjID()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.GET, "/REST/objects/1/2/latest/properties.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.Get, "/REST/objects/1/2/latest/properties.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.GetProperties(1, 2);
@@ -127,7 +127,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertiesAsync_ObjID()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.GET, "/REST/objects/1/2/latest/properties.aspx");
+			var runner = new RestApiTestRunner<List<PropertyValue>>(Method.Get, "/REST/objects/1/2/latest/properties.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.GetPropertiesAsync(1, 2);
@@ -149,7 +149,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetPropertiesOfMultipleObjects()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.POST, "/REST/objects/properties.aspx");
+			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.Post, "/REST/objects/properties.aspx");
 
 			// Create the object to send in the body.
 			var body = new ObjVer()
@@ -178,7 +178,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertiesOfMultipleObjectsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.POST, "/REST/objects/properties.aspx");
+			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.Post, "/REST/objects/properties.aspx");
 
 			// Create the object to send in the body.
 			var body = new ObjVer()
@@ -208,7 +208,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetPropertiesOfMultipleObjects_ExceptionForNoVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.POST, "/REST/objects/properties.aspx");
+			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.Post, "/REST/objects/properties.aspx");
 
 			// Create the object to send in the body.
 			var body = new ObjVer()
@@ -237,7 +237,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertiesOfMultipleObjectsAsync_ExceptionForNoVersion()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.POST, "/REST/objects/properties.aspx");
+			var runner = new RestApiTestRunner<List<List<PropertyValue>>>(Method.Post, "/REST/objects/properties.aspx");
 
 			// Create the object to send in the body.
 			var body = new ObjVer()
@@ -269,7 +269,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetProperty()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, "/REST/objects/1/2/latest/properties/0");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Put, "/REST/objects/1/2/latest/properties/0");
 
 			// Create the object to send in the body.
 			var body = new PropertyValue()
@@ -299,7 +299,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SetPropertyAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, "/REST/objects/1/2/latest/properties/0");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Put, "/REST/objects/1/2/latest/properties/0");
 
 			// Create the object to send in the body.
 			var body = new PropertyValue()
@@ -333,7 +333,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void RemoveProperty()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.DELETE, "/REST/objects/1/2/latest/properties/0.aspx");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Delete, "/REST/objects/1/2/latest/properties/0.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.RemoveProperty(1, 2, 0);
@@ -351,7 +351,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task RemovePropertyAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.DELETE, "/REST/objects/1/2/latest/properties/0.aspx");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Delete, "/REST/objects/1/2/latest/properties/0.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.RemovePropertyAsync(1, 2, 0);
@@ -373,7 +373,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetProperties_ReplaceAllProperties()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, "/REST/objects/1/2/latest/properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Put, "/REST/objects/1/2/latest/properties");
 
 			// Create the object to send in the body.
 			var body = new[]
@@ -406,7 +406,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetProperties_UpdateProperties()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.POST, "/REST/objects/1/2/latest/properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Post, "/REST/objects/1/2/latest/properties");
 
 			// Create the object to send in the body.
 			var body = new[]
@@ -439,7 +439,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SetPropertiesAsync_ReplaceAllProperties()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, "/REST/objects/1/2/latest/properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Put, "/REST/objects/1/2/latest/properties");
 
 			// Create the object to send in the body.
 			var body = new[]
@@ -472,7 +472,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SetPropertiesAsync_UpdateProperties()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.POST, "/REST/objects/1/2/latest/properties");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Post, "/REST/objects/1/2/latest/properties");
 
 			// Create the object to send in the body.
 			var body = new[]
@@ -508,7 +508,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SetPropertiesOfMultipleObjectsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/setmultipleobjproperties");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/setmultipleobjproperties");
 
 			// Create the expected body.
 			var body = new ObjectsUpdateInfo()
@@ -583,7 +583,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SetPropertiesOfMultipleObjects()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.PUT, "/REST/objects/setmultipleobjproperties");
+			var runner = new RestApiTestRunner<List<ExtendedObjectVersion>>(Method.Put, "/REST/objects/setmultipleobjproperties");
 
 			// Create the expected body.
 			var body = new ObjectsUpdateInfo()
@@ -663,7 +663,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task CanCompleteAssignmentAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/123/latest/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/123/latest/canCompleteAssignment.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignmentAsync(123);
@@ -681,7 +681,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void CanCompleteAssignment()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/123/latest/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/123/latest/canCompleteAssignment.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignment(123);
@@ -699,7 +699,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task CanCompleteAssignmentAsync_ObjID()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/987/latest/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/987/latest/canCompleteAssignment.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignmentAsync(new ObjID()
@@ -721,7 +721,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void CanCompleteAssignment_ObjID()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/987/latest/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/987/latest/canCompleteAssignment.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignment(new ObjID()
@@ -744,7 +744,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task CanCompleteAssignmentAsync_ObjID_ThrowsForOtherObjectType()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/987/latest/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/987/latest/canCompleteAssignment.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignmentAsync(new ObjID()
@@ -767,7 +767,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void CanCompleteAssignment_ObjID_ThrowsForOtherObjectType()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/987/latest/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/987/latest/canCompleteAssignment.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignment(new ObjID()
@@ -789,7 +789,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task CanCompleteAssignmentAsync_ObjVer()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/987/123/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/987/123/canCompleteAssignment.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignmentAsync(new ObjVer()
@@ -812,7 +812,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void CanCompleteAssignment_ObjVer()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.GET, "/REST/objects/987/123/canCompleteAssignment.aspx");
+			var runner = new RestApiTestRunner<PrimitiveType<bool>>(Method.Get, "/REST/objects/987/123/canCompleteAssignment.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.CanCompleteAssignment(new ObjVer()
@@ -839,7 +839,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ApproveAssignmentAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/456/complete.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/456/complete.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.ApproveAssignmentAsync(new ObjVer()
@@ -862,7 +862,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ApproveAssignment()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/456/complete.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/456/complete.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.ApproveAssignment(new ObjVer()
@@ -885,7 +885,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ApproveOrRejectAssignmentAsync_Approve()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/latest/complete.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/latest/complete.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.ApproveOrRejectAssignmentAsync
@@ -908,7 +908,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ApproveOrRejectAssignment_Approve()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/latest/complete.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/latest/complete.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.ApproveOrRejectAssignment
@@ -935,7 +935,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task RejectAssignmentAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/876/reject.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/876/reject.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.RejectAssignmentAsync(new ObjVer()
@@ -958,7 +958,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void RejectAssignment()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/876/reject.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/876/reject.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.RejectAssignment(new ObjVer()
@@ -981,7 +981,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task ApproveOrRejectAssignmentAsync_Reject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/latest/reject.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/latest/reject.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectPropertyOperations.ApproveOrRejectAssignmentAsync
@@ -1004,7 +1004,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void ApproveOrRejectAssignment_Reject()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ObjectVersion>(Method.PUT, "/REST/objects/10/123/latest/reject.aspx");
+			var runner = new RestApiTestRunner<ObjectVersion>(Method.Put, "/REST/objects/10/123/latest/reject.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectPropertyOperations.ApproveOrRejectAssignment
@@ -1025,7 +1025,7 @@ namespace MFaaP.MFWSClient.Tests
 		[TestMethod]
 		public async Task SetWorkflowStateAsync()
 		{
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Put, $"/REST/objects/0/1/2/workflowstate");
 
 			runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
 			// Execute.
@@ -1043,7 +1043,7 @@ namespace MFaaP.MFWSClient.Tests
 		[TestMethod]
 		public void SetWorkflowState()
 		{
-			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.PUT, $"/REST/objects/0/1/2/workflowstate");
+			var runner = new RestApiTestRunner<ExtendedObjectVersion>(Method.Put, $"/REST/objects/0/1/2/workflowstate");
 
 			runner.SetExpectedRequestBody(new ObjectWorkflowState() { StateID = 2 });
 			// Execute.

--- a/MFaaP.MFWSClient.Tests/MFWSVaultObjectSearchOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultObjectSearchOperations.cs
@@ -21,7 +21,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SearchForObjectsByStringAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.GET, $"/REST/objects?q=hello+world");
+			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.Get, $"/REST/objects?q=hello+world");
 			
 			// Execute.
 			await runner.MFWSClient.ObjectSearchOperations.SearchForObjectsByStringAsync("hello world");
@@ -38,7 +38,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SearchForObjectsByString()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.GET, $"/REST/objects?q=hello+world");
+			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.Get, $"/REST/objects?q=hello+world");
 			
 			// Execute.
 			runner.MFWSClient.ObjectSearchOperations.SearchForObjectsByString("hello world");
@@ -55,7 +55,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task SearchForObjectsByStringAsync_WithObjectType()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.GET, $"/REST/objects?q=hello+world&o=0");
+			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.Get, $"/REST/objects?q=hello+world&o=0");
 			
 			// Execute.
 			await runner.MFWSClient.ObjectSearchOperations.SearchForObjectsByStringAsync("hello world", 0);
@@ -72,7 +72,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void SearchForObjectsByString_WithObjectType()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.GET, $"/REST/objects?q=hello+world&o=0");
+			var runner = new RestApiTestRunner<Results<ObjectVersion>>(Method.Get, $"/REST/objects?q=hello+world&o=0");
 			
 			// Execute.
 			runner.MFWSClient.ObjectSearchOperations.SearchForObjectsByString("hello world", 0);
@@ -95,7 +95,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?q=hello+world"
 			);
 			
@@ -122,7 +122,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?q=hello+world"
 			);
 			
@@ -153,7 +153,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?o=123"
 			);
 			
@@ -180,7 +180,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?o=123&limit=2"
 			);
 
@@ -209,7 +209,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?o=123&limit=0"
 			);
 
@@ -237,7 +237,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?o=123"
 			);
 
@@ -266,7 +266,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?o=123"
 			);
 			
@@ -297,7 +297,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?d=include"
 			);
 			
@@ -324,7 +324,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?d=include"
 			);
 			
@@ -355,7 +355,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123=true"
 			);
 			
@@ -382,7 +382,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123=true"
 			);
 			
@@ -409,7 +409,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123=false"
 			);
 			
@@ -436,7 +436,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123=false"
 			);
 			
@@ -467,7 +467,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123=2017-01-01"
 			);
 			
@@ -494,7 +494,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123=2017-01-01"
 			);
 			
@@ -521,7 +521,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123<<=2017-01-01"
 			);
 			
@@ -548,7 +548,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123<<=2017-01-01"
 			);
 			
@@ -575,7 +575,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123<=2017-01-01"
 			);
 			
@@ -602,7 +602,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123<=2017-01-01"
 			);
 			
@@ -629,7 +629,7 @@ namespace MFaaP.MFWSClient.Tests
 			// Create our test runner.
 			var runner = new RestApiTestRunner<Results<ObjectVersion>>
 			(
-				Method.GET,
+				Method.Get,
 				$"/REST/objects?p123>>=2017-01-01"
 			);
 			
@@ -663,22 +663,21 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
+                    // Create the mock response.
+                    return Task.FromResult
+					(
+						Mock.Of<RestResponse<Results<ObjectVersion>>>
+						(
+							m => m.Data == new Results<ObjectVersion>()
+						)
+					);
 				});
 
 			/* Act */
@@ -692,7 +691,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123>>=2017-01-01", resourceAddress);
@@ -715,23 +714,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -744,7 +742,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123>=2017-01-01", resourceAddress);
@@ -767,23 +765,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
-				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                {
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -796,7 +793,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123>=2017-01-01", resourceAddress);
@@ -823,23 +820,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -852,7 +848,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123=456", resourceAddress);
@@ -875,23 +871,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -904,7 +899,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123=456", resourceAddress);
@@ -931,23 +926,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -960,7 +954,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123=456%2C789", resourceAddress);
@@ -983,23 +977,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1012,7 +1005,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123=456%2C789", resourceAddress);
@@ -1039,23 +1032,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1068,7 +1060,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123=hello", resourceAddress);
@@ -1091,23 +1083,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1120,7 +1111,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123=hello", resourceAddress);
@@ -1143,23 +1134,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1172,7 +1162,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123**=hello*", resourceAddress);
@@ -1195,23 +1185,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1224,7 +1213,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123**=hello*", resourceAddress);
@@ -1247,23 +1236,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1276,7 +1264,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123*=hello", resourceAddress);
@@ -1299,23 +1287,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1328,7 +1315,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123*=hello", resourceAddress);
@@ -1351,23 +1338,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1380,7 +1366,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123^=hello", resourceAddress);
@@ -1403,23 +1389,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1432,7 +1417,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?p123^=hello", resourceAddress);
@@ -1459,23 +1444,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1488,7 +1472,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?vl123=123", resourceAddress);
@@ -1511,23 +1495,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<Results<ObjectVersion>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new Results<ObjectVersion>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<Results<ObjectVersion>>>
+                        (
+                            m => m.Data == new Results<ObjectVersion>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -1540,7 +1523,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<Results<ObjectVersion>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/objects?vl123=ehello", resourceAddress);

--- a/MFaaP.MFWSClient.Tests/MFWSVaultObjectTypeOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultObjectTypeOperations.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 
 namespace MFaaP.MFWSClient.Tests
@@ -19,10 +20,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectTypeIDByAliasAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/objecttypes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/objecttypes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -40,10 +41,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectTypeIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/objecttypes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/objecttypes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -61,10 +62,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectTypeIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/objecttypes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/objecttypes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -82,10 +83,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectTypeIDByAlias()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/objecttypes/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/objecttypes/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -107,7 +108,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetObjectTypesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ObjType>>(Method.GET, "/REST/structure/objecttypes.aspx");
+			var runner = new RestApiTestRunner<List<ObjType>>(Method.Get, "/REST/structure/objecttypes.aspx");
 
 			// Execute.
 			await runner.MFWSClient.ObjectTypeOperations.GetObjectTypesAsync();
@@ -124,7 +125,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetObjectTypes()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ObjType>>(Method.GET, "/REST/structure/objecttypes.aspx");
+			var runner = new RestApiTestRunner<List<ObjType>>(Method.Get, "/REST/structure/objecttypes.aspx");
 
 			// Execute.
 			runner.MFWSClient.ObjectTypeOperations.GetObjectTypes();

--- a/MFaaP.MFWSClient.Tests/MFWSVaultPropertyDefOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultPropertyDefOperations.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 
 namespace MFaaP.MFWSClient.Tests
@@ -21,10 +22,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertyDefIDByAliasAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/properties/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/properties/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -42,10 +43,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetPropertyDefIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/properties/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/properties/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -63,10 +64,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetPropertyDefIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/properties/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/properties/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -84,10 +85,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetPropertyDefIDByAlias()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/properties/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/properties/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -118,23 +119,23 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<List<PropertyDef>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new List<PropertyDef>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<PropertyDef>>>
+                        (
+                            m => m.Data == new List<PropertyDef>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -147,7 +148,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/structure/properties", resourceAddress);
@@ -170,23 +171,23 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<List<PropertyDef>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new List<PropertyDef>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<PropertyDef>>>
+                        (
+                            m => m.Data == new List<PropertyDef>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -199,7 +200,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/structure/properties", resourceAddress);
@@ -222,23 +223,23 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					methodUsed = r.Method;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<List<PropertyDef>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new List<PropertyDef>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<PropertyDef>>>
+                        (
+                            m => m.Data == new List<PropertyDef>()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -251,10 +252,10 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Method must be correct.
-			Assert.AreEqual(Method.GET, methodUsed);
+			Assert.AreEqual(Method.Get, methodUsed);
 		}
 
 		/// <summary>
@@ -274,22 +275,21 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					methodUsed = r.Method;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<List<PropertyDef>>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new List<PropertyDef>());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<List<PropertyDef>>>
+                        (
+                            m => m.Data == new List<PropertyDef>()
+                        )
+                    );
 				});
 
 			/* Act */
@@ -303,10 +303,10 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<List<PropertyDef>>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Method must be correct.
-			Assert.AreEqual(Method.GET, methodUsed);
+			Assert.AreEqual(Method.Get, methodUsed);
 		}
 
 		#endregion
@@ -330,23 +330,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<PropertyDef>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new PropertyDef());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<PropertyDef>>
+                        (
+                            m => m.Data == new PropertyDef()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -359,7 +358,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/structure/properties/123", resourceAddress);
@@ -382,23 +381,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					resourceAddress = r.Resource;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<PropertyDef>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new PropertyDef());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<PropertyDef>>
+                        (
+                            m => m.Data == new PropertyDef()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -411,7 +409,7 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Resource must be correct.
 			Assert.AreEqual("/REST/structure/properties/567", resourceAddress);
@@ -434,23 +432,22 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					methodUsed = r.Method;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<PropertyDef>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new PropertyDef());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
-				});
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<PropertyDef>>
+                        (
+                            m => m.Data == new PropertyDef()
+                        )
+                    );
+                });
 
 			/* Act */
 
@@ -463,10 +460,10 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Method must be correct.
-			Assert.AreEqual(Method.GET, methodUsed);
+			Assert.AreEqual(Method.Get, methodUsed);
 		}
 
 		/// <summary>
@@ -486,22 +483,21 @@ namespace MFaaP.MFWSClient.Tests
 
 			// When the execute method is called, log the resource requested.
 			mock
-				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()))
-				.Callback((IRestRequest r, Method m, CancellationToken t) => {
+				.Setup(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()))
+				.Callback((RestRequest r, CancellationToken t) => {
 					methodUsed = r.Method;
 				})
 				// Return a mock response.
 				.Returns(() =>
 				{
-					// Create the mock response.
-					var response = new Mock<IRestResponse<PropertyDef>>();
-
-					// Setup the return data.
-					response.SetupGet(r => r.Data)
-						.Returns(new PropertyDef());
-
-					//Return the mock object.
-					return Task.FromResult(response.Object);
+                    // Create the mock response.
+                    return Task.FromResult
+                    (
+                        Mock.Of<RestResponse<PropertyDef>>
+                        (
+                            m => m.Data == new PropertyDef()
+                        )
+                    );
 				});
 
 			/* Act */
@@ -515,10 +511,10 @@ namespace MFaaP.MFWSClient.Tests
 			/* Assert */
 
 			// Execute must be called once.
-			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<IRestRequest>(), It.IsAny<Method>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+			mock.Verify(c => c.ExecuteAsync<PropertyDef>(It.IsAny<RestRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
 			// Method must be correct.
-			Assert.AreEqual(Method.GET, methodUsed);
+			Assert.AreEqual(Method.Get, methodUsed);
 		}
 
 		#endregion

--- a/MFaaP.MFWSClient.Tests/MFWSVaultValueListItemOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultValueListItemOperations.cs
@@ -22,7 +22,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetValueListItemsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items");
 
 			// Execute.
 			await runner.MFWSClient.ValueListItemOperations.GetValueListItemsAsync(1);
@@ -39,7 +39,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetValueListItems()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items");
 
 			// Execute.
 			runner.MFWSClient.ValueListItemOperations.GetValueListItems(1);
@@ -56,7 +56,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetValueListItemsAsync_WithNameFilter()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items?filter=hello");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items?filter=hello");
 
 			// Execute.
 			await runner.MFWSClient.ValueListItemOperations.GetValueListItemsAsync(1, "hello");
@@ -73,7 +73,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetValueListItems_WithNameFilter()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items?filter=hello");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items?filter=hello");
 
 			// Execute.
 			runner.MFWSClient.ValueListItemOperations.GetValueListItems(1, "hello");
@@ -90,7 +90,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetValueListItemsAsync_WithLimit()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items?limit=501");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items?limit=501");
 
 			// Execute.
 			await runner.MFWSClient.ValueListItemOperations.GetValueListItemsAsync(1, limit: 501);
@@ -107,7 +107,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetValueListItems_WithLimit()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items?limit=501");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items?limit=501");
 
 			// Execute.
 			runner.MFWSClient.ValueListItemOperations.GetValueListItems(1, limit: 501);
@@ -124,7 +124,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetValueListItemsAsync_WithLimitAndNameFilter()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items?filter=hello&limit=501");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items?filter=hello&limit=501");
 
 			// Execute.
 			await runner.MFWSClient.ValueListItemOperations.GetValueListItemsAsync(1, "hello", limit: 501);
@@ -141,7 +141,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetValueListItems_WithLimitAndNameFilter()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.GET, "/REST/valuelists/1/items?filter=hello&limit=501");
+			var runner = new RestApiTestRunner<Results<ValueListItem>>(Method.Get, "/REST/valuelists/1/items?filter=hello&limit=501");
 
 			// Execute.
 			runner.MFWSClient.ValueListItemOperations.GetValueListItems(1, "hello", limit: 501);
@@ -162,7 +162,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AddValueListItemByNameAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/1/items");
 
 			// Set the expected body.
 			var newVLitem = new ValueListItem
@@ -189,7 +189,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AddValueListItemByNameAsyncThrowsWithNullName()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/1/items");
 
 			// Execute.
 			await runner.MFWSClient.ValueListItemOperations.AddValueListItemAsync(1, newItemName: null);
@@ -204,7 +204,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AddValueListItemByNameAsyncThrowsWithBlankName()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/1/items");
 
 			// Execute.
 			await runner.MFWSClient.ValueListItemOperations.AddValueListItemAsync(1, newItemName: "");
@@ -218,7 +218,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void AddValueListItemByName()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/1/items");
 
 			// Set the expected body.
 			var newVLitem = new ValueListItem
@@ -245,7 +245,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AddValueListItemAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/1/items");
 
 			// Set the expected body.
 			var newVLitem = new ValueListItem
@@ -275,7 +275,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AddValueListItemValueListIDPopulatedAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/23/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/23/items");
 
 			// Set the expected body.
 			var newVLitem = new ValueListItem
@@ -309,7 +309,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task AddValueListItemAsyncThrowsWithNull()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/1/items");
 
 			// Execute.
 			await runner.MFWSClient.ValueListItemOperations.AddValueListItemAsync(1, valueListItem: null);
@@ -323,7 +323,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void AddValueListItem()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<ValueListItem>(Method.POST, "/REST/valuelists/1/items");
+			var runner = new RestApiTestRunner<ValueListItem>(Method.Post, "/REST/valuelists/1/items");
 
 			// Set the expected body.
 			var newVLitem = new ValueListItem

--- a/MFaaP.MFWSClient.Tests/MFWSVaultValueListOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultValueListOperations.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 
 namespace MFaaP.MFWSClient.Tests
@@ -21,10 +22,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetValueListIDByAliasAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/valuelists/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/valuelists/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -42,10 +43,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetValueListIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/valuelists/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/valuelists/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -63,10 +64,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetValueListIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/valuelists/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/valuelists/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -84,10 +85,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetValueListIDByAlias()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/valuelists/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/valuelists/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -109,7 +110,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetValueListsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ObjType>>(Method.GET, "/REST/valuelists.aspx");
+			var runner = new RestApiTestRunner<List<ObjType>>(Method.Get, "/REST/valuelists.aspx");
 
 			// Set up the expected body.
 
@@ -128,7 +129,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetValueLists()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<ObjType>>(Method.GET, "/REST/valuelists.aspx");
+			var runner = new RestApiTestRunner<List<ObjType>>(Method.Get, "/REST/valuelists.aspx");
 
 			// Set up the expected body.
 

--- a/MFaaP.MFWSClient.Tests/MFWSVaultViewOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultViewOperations.cs
@@ -20,7 +20,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetExternalViewFolderAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/umyrepository%3A12%2B3456/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/umyrepository%3A12%2B3456/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync(new FolderContentItem()
@@ -49,7 +49,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetRootViewContentsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetRootFolderContentsAsync();
@@ -66,7 +66,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetRootViewContents()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/items");
 
 			// Execute.
 			runner.MFWSClient.ViewOperations.GetRootFolderContents();
@@ -87,7 +87,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync();
@@ -104,7 +104,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetViewContents()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/items");
 
 			// Execute.
 			runner.MFWSClient.ViewOperations.GetFolderContents();
@@ -121,7 +121,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync_WithView()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v15/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v15/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync(new FolderContentItem()
@@ -146,7 +146,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetViewContents_WithView()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v15/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v15/items");
 
 			// Execute.
 			runner.MFWSClient.ViewOperations.GetFolderContents(new FolderContentItem()
@@ -171,7 +171,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync_WithView_OneGrouping()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v216/L4/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v216/L4/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync(new FolderContentItem()
@@ -207,7 +207,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetViewContents_WithView_OneGrouping()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v216/L4/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v216/L4/items");
 
 			// Execute.
 			runner.MFWSClient.ViewOperations.GetFolderContents(new FolderContentItem()
@@ -243,7 +243,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync_WithView_TwoGroupings()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v216/L4/L19/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v216/L4/L19/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync(new FolderContentItem()
@@ -290,7 +290,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetViewContents_WithView_TwoGroupings()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v216/L4/L19/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v216/L4/L19/items");
 
 			// Execute.
 			runner.MFWSClient.ViewOperations.GetFolderContents(new FolderContentItem()
@@ -337,7 +337,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync_WithView_OneGrouping_UrlEncoded()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v216/TIntelligent+Metadata+Layer/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v216/TIntelligent+Metadata+Layer/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync(new FolderContentItem()
@@ -370,7 +370,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync_WithView_OneGrouping_UrlEncoded_WithSlashes()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v216/TOne%2FTwo+Options/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v216/TOne%2FTwo+Options/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync(new FolderContentItem()
@@ -403,7 +403,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync_CorrectResource_ViewPathMustEndWithSlash()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v123/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v123/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync("v123");
@@ -420,7 +420,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetViewContentsAsync_CorrectResource_ViewPathMustNotStartWithSlash()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<FolderContentItems>(Method.GET, $"/REST/views/v123/items");
+			var runner = new RestApiTestRunner<FolderContentItems>(Method.Get, $"/REST/views/v123/items");
 
 			// Execute.
 			await runner.MFWSClient.ViewOperations.GetFolderContentsAsync("/v123/");

--- a/MFaaP.MFWSClient.Tests/MFWSVaultWorkflowOperations.cs
+++ b/MFaaP.MFWSClient.Tests/MFWSVaultWorkflowOperations.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 
 namespace MFaaP.MFWSClient.Tests
@@ -18,7 +19,7 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetWorkflowStatesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.GET, "/REST/structure/workflows/1234/states.aspx");
+			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.Get, "/REST/structure/workflows/1234/states.aspx");
 
 			// Execute.
 			await runner.MFWSClient.WorkflowOperations.GetWorkflowStatesAsync(1234);
@@ -35,7 +36,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowStates()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.GET, "/REST/structure/workflows/12345/states.aspx");
+			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.Get, "/REST/structure/workflows/12345/states.aspx");
 
 			// Execute.
 			runner.MFWSClient.WorkflowOperations.GetWorkflowStates(12345);
@@ -52,7 +53,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowStateByName_IncludesWorkflow()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.GET, "/REST/structure/workflows/12345/states.aspx");
+			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.Get, "/REST/structure/workflows/12345/states.aspx");
 
 			// Set up the response to include
 			runner.ResponseData = new List<WorkflowState>
@@ -88,7 +89,7 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowStateByName_DoesNotIncludeWorkflow()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.GET, "/REST/structure/workflows/123/states.aspx");
+			var runner = new RestApiTestRunner<List<WorkflowState>>(Method.Get, "/REST/structure/workflows/123/states.aspx");
 
 			// Set up the response to include
 			runner.ResponseData = new List<WorkflowState>
@@ -127,10 +128,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetWorkflowIDByAliasAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflows/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflows/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -148,10 +149,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetWorkflowIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflows/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflows/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -169,10 +170,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflows/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflows/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -190,10 +191,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowIDByAlias()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflows/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflows/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -215,10 +216,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetWorkflowStateIDByAliasAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflowstates/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflowstates/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -236,10 +237,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetWorkflowStateIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflowstates/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflowstates/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -257,10 +258,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowStateIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflowstates/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflowstates/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -278,10 +279,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowStateIDByAlias()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/workflowstates/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/workflowstates/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -303,10 +304,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetWorkflowStateTransitionIDByAliasAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/statetransitions/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/statetransitions/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -324,10 +325,10 @@ namespace MFaaP.MFWSClient.Tests
 		public async Task GetWorkflowStateTransitionIDsByAliasesAsync()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/statetransitions/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/statetransitions/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -345,10 +346,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowStateTransitionIDsByAliases()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/statetransitions/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/statetransitions/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello", "world", "third option" };
+			var body = new JArray { "hello", "world", "third option" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.
@@ -366,10 +367,10 @@ namespace MFaaP.MFWSClient.Tests
 		public void GetWorkflowStateTransitionIDByAlias()
 		{
 			// Create our test runner.
-			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.POST, "/REST/structure/statetransitions/itemidbyalias.aspx");
+			var runner = new RestApiTestRunner<Dictionary<string, int>>(Method.Post, "/REST/structure/statetransitions/itemidbyalias.aspx");
 
 			// Set up the expected body.
-			var body = new JsonArray { "hello world" };
+			var body = new JArray { "hello world" };
 			runner.SetExpectedRequestBody(body);
 
 			// Execute.

--- a/MFaaP.MFWSClient.Tests/MFaaP.MFWSClient.Tests.csproj
+++ b/MFaaP.MFWSClient.Tests/MFaaP.MFWSClient.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MFaaP.MFWSClient.Tests</RootNamespace>
     <AssemblyName>MFaaP.MFWSClient.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -88,7 +89,7 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="RestSharp">
-      <Version>106.12.0</Version>
+      <Version>108.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <Choose>

--- a/MFaaP.MFWSClient/ExtensionMethods/DictionaryExtensionMethods.cs
+++ b/MFaaP.MFWSClient/ExtensionMethods/DictionaryExtensionMethods.cs
@@ -18,7 +18,7 @@ namespace MFaaP.MFWSClient.ExtensionMethods
 		/// <param name="key">The key to look up.</param>
 		/// <param name="defaultValue">The default value to return if the key cannot be found.</param>
 		/// <returns>The value in the dictionary with the supplied key, or a default value if not found.</returns>
-		public static TB GetValueOrDefault<TA, TB>(this Dictionary<TA, TB> dictionary, TA key, TB defaultValue = default(TB))
+		public static TB GetValueOrDefault<TA, TB>(this Dictionary<TA, TB> dictionary, TA key, TB defaultValue = default)
 		{
 			// Sanity.
 			if(null == dictionary)

--- a/MFaaP.MFWSClient/MFWSClient.Authentication.OAuth.cs
+++ b/MFaaP.MFWSClient/MFWSClient.Authentication.OAuth.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MFaaP.MFWSClient.ExtensionMethods;
 using MFaaP.MFWSClient.OAuth2;
+using RestSharp;
 
 namespace MFaaP.MFWSClient
 {
@@ -62,7 +63,7 @@ namespace MFaaP.MFWSClient
 		protected OAuth2TokenResponse ConvertOAuth2AuthorizationCodeToTokens(
 			OAuth2Configuration pluginConfiguration, 
 			string code,
-			CancellationToken cancellationToken = default(CancellationToken))
+			CancellationToken cancellationToken = default)
 		{
 			// Sanity.
 			if (null == pluginConfiguration)
@@ -89,7 +90,7 @@ namespace MFaaP.MFWSClient
 		protected async Task<OAuth2TokenResponse> ConvertOAuth2AuthorizationCodeToTokensAsync(
 			OAuth2Configuration pluginConfiguration,
 			string code,
-			CancellationToken cancellationToken = default( CancellationToken ) )
+			CancellationToken cancellationToken = default )
 		{
 			// Sanity.
 			if( null == pluginConfiguration )
@@ -99,8 +100,8 @@ namespace MFaaP.MFWSClient
 
 			// Create the request, adding the mandatory items.
 			var tokenEndpoint = new Uri( pluginConfiguration.TokenEndpoint, uriKind: UriKind.Absolute );
-			var request = new RestSharp.RestRequest( tokenEndpoint.PathAndQuery, RestSharp.Method.POST );
-			request.AddParameter( "code", code );
+			var request = new RestSharp.RestRequest( tokenEndpoint.PathAndQuery, RestSharp.Method.Post );
+			request.AddParameter( new QueryParameter("code", code) );
 			request.AddParameter( "grant_type", pluginConfiguration.GrantType );
 			request.AddParameter( "redirect_uri", pluginConfiguration.GetAppropriateRedirectUri() );
 
@@ -144,7 +145,7 @@ namespace MFaaP.MFWSClient
 			OAuth2Configuration pluginConfiguration,
 			OAuth2TokenResponse oAuthTokens,
 			bool setHttpHeaders = true,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.RefreshOAuth2TokenAsync(pluginConfiguration, oAuthTokens, setHttpHeaders, token)
@@ -165,7 +166,7 @@ namespace MFaaP.MFWSClient
 			OAuth2Configuration pluginConfiguration,
 			string refreshToken,
 			bool setHttpHeaders = true,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.RefreshOAuth2TokenAsync(pluginConfiguration, refreshToken, setHttpHeaders, token)
@@ -186,7 +187,7 @@ namespace MFaaP.MFWSClient
 			OAuth2Configuration pluginConfiguration,
 			OAuth2TokenResponse oAuthTokens,
 			bool setHttpHeaders = true,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == pluginConfiguration)
@@ -210,7 +211,7 @@ namespace MFaaP.MFWSClient
 			OAuth2Configuration pluginConfiguration,
 			string refreshToken,
 			bool setHttpHeaders = true,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == pluginConfiguration)
@@ -220,7 +221,7 @@ namespace MFaaP.MFWSClient
 
 			// Create the request, adding the mandatory items.
 			var tokenEndpoint = new Uri(pluginConfiguration.TokenEndpoint, uriKind: UriKind.Absolute);
-			var request = new RestSharp.RestRequest(tokenEndpoint.PathAndQuery, RestSharp.Method.POST);
+			var request = new RestSharp.RestRequest(tokenEndpoint.PathAndQuery, RestSharp.Method.Post);
 			request.AddParameter("grant_type", "refresh_token");
 			request.AddParameter("refresh_token", refreshToken);
 			request.AddParameter("redirect_uri", pluginConfiguration.GetAppropriateRedirectUri());
@@ -272,7 +273,7 @@ namespace MFaaP.MFWSClient
 			OAuth2Configuration configuration,
 			Uri redirectionUri,
 			bool setHttpHeaders = true,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == configuration)
@@ -301,7 +302,7 @@ namespace MFaaP.MFWSClient
 			OAuth2Configuration configuration,
 			Uri redirectionUri,
 			bool setHttpHeaders = true,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == configuration)

--- a/MFaaP.MFWSClient/MFWSClient.Session.cs
+++ b/MFaaP.MFWSClient/MFWSClient.Session.cs
@@ -12,7 +12,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task.</returns>
-		public async Task<Vault> GetCurrentSessionVaultAsync(CancellationToken token = default(CancellationToken))
+		public async Task<Vault> GetCurrentSessionVaultAsync(CancellationToken token = default)
 		{
 			// Build up the request.
 			var request = new RestRequest("/REST/session/vault");
@@ -30,7 +30,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The vault returned by the request.</returns>
-		public Vault GetCurrentSessionVault(CancellationToken token = default(CancellationToken))
+		public Vault GetCurrentSessionVault(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetCurrentSessionVaultAsync(token)
@@ -44,7 +44,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task.</returns>
-		public async Task<SessionInfo> GetCurrentSessionInfoAsync(CancellationToken token = default(CancellationToken))
+		public async Task<SessionInfo> GetCurrentSessionInfoAsync(CancellationToken token = default)
 		{
 			// Build up the request.
 			var request = new RestRequest("/REST/session");
@@ -62,7 +62,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The vault returned by the request.</returns>
-		public SessionInfo GetCurrentSessionInfo(CancellationToken token = default(CancellationToken))
+		public SessionInfo GetCurrentSessionInfo(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetCurrentSessionInfoAsync(token)

--- a/MFaaP.MFWSClient/MFWSClient.cs
+++ b/MFaaP.MFWSClient/MFWSClient.cs
@@ -1,4 +1,5 @@
 ﻿using RestSharp;
+using System;
 
 namespace MFaaP.MFWSClient
 {
@@ -6,21 +7,31 @@ namespace MFaaP.MFWSClient
 		: MFWSClientBase
 	{
 
-		/// <summary>
-		/// Creates an MFWSClient pointing at the MFWA site.
-		/// </summary>
-		/// <param name="baseUrl">The base url of the MFWA (web access) site; note that this should be of the form
-		/// "http://localhost", not of the form "http://localhost/REST".</param>
-		public MFWSClient(string baseUrl)
-			: base(baseUrl)
-		{
-		}
+        /// <summary>
+        /// Creates an MFWSClient pointing at the MFWA site.
+        /// </summary>
+        /// <param name="baseUrl">The base url of the MFWA (web access) site; note that this should be of the form
+        /// "http://localhost", not of the form "http://localhost/REST".</param>
+        public MFWSClient(string baseUrl)
+            : base(baseUrl)
+        {
+        }
 
-		/// <summary>
-		/// Creates an MFWSClient pointing at the MFWA site.
-		/// </summary>
-		/// <param name="restClient">The <see cref="IRestClient"/> to use for HTTP requests.</param>
-		protected MFWSClient(IRestClient restClient)
+        /// <summary>
+        /// Creates an MFWSClient pointing at the MFWA site.
+        /// </summary>
+        /// <param name="baseUrl">The base url of the MFWA (web access) site; note that this should be of the form
+        /// "http://localhost", not of the form "http://localhost/REST".</param>
+        public MFWSClient(Uri baseUrl)
+            : base(baseUrl)
+        {
+        }
+
+        /// <summary>
+        /// Creates an MFWSClient pointing at the MFWA site.
+        /// </summary>
+        /// <param name="restClient">The <see cref="IRestClient"/> to use for HTTP requests.</param>
+        protected MFWSClient(IRestClient restClient)
 			: base(restClient)
 		{
 		}

--- a/MFaaP.MFWSClient/MFWSClientBase.HttpRequests.cs
+++ b/MFaaP.MFWSClient/MFWSClientBase.HttpRequests.cs
@@ -5,8 +5,6 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
-using RestSharp.Deserializers;
-using RestSharp.Serialization.Json;
 
 namespace MFaaP.MFWSClient
 {
@@ -37,15 +35,10 @@ namespace MFaaP.MFWSClient
 		public event AfterExecuteRequestHandler AfterExecuteRequest;
 
 		/// <summary>
-		/// The deserialiser used for deserialising exception data.
-		/// </summary>
-		private static readonly JsonDeserializer jsonDeserializer = new JsonDeserializer();
-
-		/// <summary>
 		/// Handles any exceptions returned by the web service, throwing exceptions as needed.
 		/// </summary>
 		/// <param name="response">The response returned by the web service.</param>
-		protected virtual void EnsureValidResponse(IRestResponse response)
+		protected virtual void EnsureValidResponse(RestResponse response)
 		{
 			// Sanity.
 			if (null == response)
@@ -78,7 +71,8 @@ namespace MFaaP.MFWSClient
 				case HttpStatusCode.MethodNotAllowed:
 					{
 						// Parse exception information, if we can.
-						var error = MFWSClientBase.jsonDeserializer.Deserialize<WebServiceError>(response);
+						var deserializer = new RestSharp.Serializers.Json.SystemTextJsonSerializer();
+						var error = deserializer.Deserialize<WebServiceError>(response);
 
 						// TODO: Stack doesn't seem to be deserialised properly.
 
@@ -103,7 +97,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="request">The request to execute.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse<T>> Get<T>(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse<T>> Get<T>(RestRequest request, CancellationToken token = default)
 			where T : new()
 		{
 			// Sanity.
@@ -111,12 +105,10 @@ namespace MFaaP.MFWSClient
 				throw new ArgumentNullException(nameof(request));
 
 			// Ensure method is correct.
-			request.Method = Method.GET;
+			request.Method = Method.Get;
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -125,7 +117,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync<T>(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync<T>(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -141,19 +133,17 @@ namespace MFaaP.MFWSClient
 		/// <param name="request">The request to execute.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse> Get(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse> Get(RestRequest request, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == request)
 				throw new ArgumentNullException(nameof(request));
 
 			// Ensure method is correct.
-			request.Method = Method.GET;
+			request.Method = Method.Get;
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -162,7 +152,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -178,19 +168,17 @@ namespace MFaaP.MFWSClient
 		/// <param name="request">The request to execute.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse> Post(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse> Post(RestRequest request, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == request)
 				throw new ArgumentNullException(nameof(request));
 
 			// Ensure method is correct.
-			request.Method = Method.POST;
+			request.Method = Method.Post;
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -199,7 +187,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -216,7 +204,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <param name="request">The request to execute.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse<T>> Post<T>(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse<T>> Post<T>(RestRequest request, CancellationToken token = default)
 			where T : new()
 		{
 			// Sanity.
@@ -224,12 +212,10 @@ namespace MFaaP.MFWSClient
 				throw new ArgumentNullException(nameof(request));
 
 			// Ensure method is correct.
-			request.Method = Method.POST;
+			request.Method = Method.Post;
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -238,7 +224,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync<T>(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync<T>(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -254,7 +240,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="request">The request to execute.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse> Delete(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse> Delete(RestRequest request, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == request)
@@ -262,13 +248,11 @@ namespace MFaaP.MFWSClient
 
 			// Ensure method is correct.
 			// Note: we don't set the method to DELETE as this is not supported in some IIS instances.
-			request.Method = Method.POST;
+			request.Method = Method.Post;
 			request.AddQueryParameter("_method", "DELETE");
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -277,7 +261,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -294,7 +278,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <param name="request">The request to execute.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse<T>> Delete<T>(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse<T>> Delete<T>(RestRequest request, CancellationToken token = default)
 			where T : new()
 		{
 			// Sanity.
@@ -303,13 +287,11 @@ namespace MFaaP.MFWSClient
 
 			// Ensure method is correct.
 			// Note: we don't set the method to DELETE as this is not supported in some IIS instances.
-			request.Method = Method.POST;
+			request.Method = Method.Post;
 			request.AddQueryParameter("_method", "DELETE");
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -318,7 +300,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync<T>(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync<T>(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -334,7 +316,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="request">The request to execute.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse> Put(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse> Put(RestRequest request, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == request)
@@ -342,13 +324,11 @@ namespace MFaaP.MFWSClient
 
 			// Ensure method is correct.
 			// Note: we don't set the method to PUT as this is not supported in some IIS instances.
-			request.Method = Method.POST;
+			request.Method = Method.Post;
 			request.AddQueryParameter("_method", "PUT");
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -357,7 +337,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -374,7 +354,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="request">The request to execute.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response.</returns>
-		public async Task<IRestResponse<T>> Put<T>(IRestRequest request, CancellationToken token = default(CancellationToken))
+		public async Task<RestResponse<T>> Put<T>(RestRequest request, CancellationToken token = default)
 			where T : new()
 		{
 			// Sanity.
@@ -383,13 +363,11 @@ namespace MFaaP.MFWSClient
 
 			// Ensure method is correct.
 			// Note: we don't set the method to PUT as this is not supported in some IIS instances.
-			request.Method = Method.POST;
+			request.Method = Method.Post;
 			request.AddQueryParameter("_method", "PUT");
 
 			// We only deal with Json.
-#pragma warning disable CS0618 // Type or member is obsolete
 			request.RequestFormat = DataFormat.Json;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Ensure the extensions headers are specified.
 			this.EnsureEnabledExtensionsAreSpecified(request);
@@ -398,7 +376,7 @@ namespace MFaaP.MFWSClient
 			this.OnBeforeExecuteRequest(request);
 
 			// Execute the request.
-			var response = await this.restClient.ExecuteAsync<T>(request, request.Method, token)
+			var response = await this.RestClient.ExecuteAsync<T>(request, token)
 				.ConfigureAwait(false);
 
 			// Notify after the request.
@@ -413,7 +391,7 @@ namespace MFaaP.MFWSClient
 		/// contained within the <see cref="ExtensionsHttpHeaderName"/> HTTP header on the request.
 		/// </summary>
 		/// <param name="request">The request to alter.</param>
-		public virtual void EnsureEnabledExtensionsAreSpecified(IRestRequest request)
+		public virtual void EnsureEnabledExtensionsAreSpecified(RestRequest request)
 		{
 			// Sanity.
 			if(null == request)
@@ -425,9 +403,7 @@ namespace MFaaP.MFWSClient
 
 			// Retrieve the current X-Extensions values (comma-separated) as an array.
 			// Need to handle various null/empty scenarios here.
-#pragma warning disable CS0618 // Type or member is obsolete
-			var existingExtensions = ((request.Parameters ?? new List<Parameter>())
-#pragma warning restore CS0618 // Type or member is obsolete
+			var existingExtensions = ((request.Parameters ?? new ParametersCollection())
 										.FirstOrDefault(p =>
 											p.Type == ParameterType.HttpHeader
 											&& p.Name == MFWSClientBase.ExtensionsHttpHeaderName)?
@@ -454,8 +430,8 @@ namespace MFaaP.MFWSClient
 			}
 
 			// Remove the existing header, if it exists.
-			request.Parameters?
-				.RemoveAll(p => p.Type == ParameterType.HttpHeader && p.Name == MFWSClientBase.ExtensionsHttpHeaderName);
+			foreach (var h in request.Parameters.Where(p => p.Type == ParameterType.HttpHeader && p.Name == MFWSClientBase.ExtensionsHttpHeaderName))
+				request.Parameters?.RemoveParameter(h.Name);
 
 			// Add the header.
 			request.AddHeader(MFWSClientBase.ExtensionsHttpHeaderName, string.Join(",", existingExtensions));
@@ -466,7 +442,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="e">The request being executed.</param>
 		/// <remarks>Ensures that the request contains any <see cref="EnabledMFWSExtensions"/>.  This base implementation should always be called.</remarks>
-		protected virtual void OnBeforeExecuteRequest(IRestRequest e)
+		protected virtual void OnBeforeExecuteRequest(RestRequest e)
 		{
 #if DEBUG
 			// Output the basic request data.
@@ -498,7 +474,7 @@ namespace MFaaP.MFWSClient
 				// ReSharper disable once PossibleNullReferenceException
 				foreach (var file in e.Files)
 				{
-					System.Diagnostics.Debug.WriteLine($"\tFile {file.Name} ({file.ContentLength}b)");
+					System.Diagnostics.Debug.WriteLine($"\tFile {file.Name} ({file.GetFile().Length}b)");
 				}
 			}
 #endif
@@ -511,7 +487,7 @@ namespace MFaaP.MFWSClient
 		/// Notifies any subscribers of <see cref="AfterExecuteRequest"/>
 		/// </summary>
 		/// <param name="e"></param>
-		protected virtual void OnAfterExecuteRequest(IRestResponse e)
+		protected virtual void OnAfterExecuteRequest(RestResponse e)
 		{
 #if DEBUG
 			if (null != e)

--- a/MFaaP.MFWSClient/MFWSStructs.cs
+++ b/MFaaP.MFWSClient/MFWSStructs.cs
@@ -2905,37 +2905,37 @@ namespace MFaaP.MFWSClient
 		/// List of temporary file upload ids.
 		/// </summary>
 		/// <remarks>May be empty.</remarks>
-		public List<int> UploadIds = new List<int>();
+		public List<int> UploadIds { get; set; } = new List<int>();
 
 		/// <summary>
 		/// Array of object's current property values.
 		/// </summary>
 		/// <remarks>May be empty.</remarks>
-		public List<PropertyValue> PropertyValues = new List<PropertyValue>();
+		public List<PropertyValue> PropertyValues { get; set; } = new List<PropertyValue>();
 
 		/// <summary>
 		/// Object type.
 		/// </summary>
-		public int ObjectType;
+		public int ObjectType { get; set; }
 
-		/// <summary>
-		/// ObjVer of current object.
-		/// </summary>
-		/// <remarks>May be empty.</remarks>
-		public ObjVer ObjVer;
+        /// <summary>
+        /// ObjVer of current object.
+        /// </summary>
+        /// <remarks>May be empty.</remarks>
+        public ObjVer ObjVer { get; set; }
 
-		/// <summary>
-		/// List of metadata provider ids.
-		/// </summary>
-		/// <remarks>May be empty to return all data, or include values to filter.</remarks>
-		public List<string> MetadataProviderIds = new List<string>();
+        /// <summary>
+        /// List of metadata provider ids.
+        /// </summary>
+        /// <remarks>May be empty to return all data, or include values to filter.</remarks>
+        public List<string> MetadataProviderIds { get; set; }  = new List<string>();
 
 		/// <summary>
 		/// Custom data.
 		/// </summary>
 		/// <remarks>May be empty.</remarks>
-		public string CustomData;
-	}
+		public string CustomData { get; set; }
+    }
 	
 	/// <summary>
 	/// Based on M-Files API.
@@ -3103,7 +3103,7 @@ namespace MFaaP.MFWSClient
 		/// <summary>
 		/// Info for multiple objects.
 		/// </summary>
-		public List<ObjectVersionUpdateInformation> MultipleObjectInfo;
+		public List<ObjectVersionUpdateInformation> MultipleObjectInfo { get; set; }
 	}
 
 	/// <summary>
@@ -3115,8 +3115,8 @@ namespace MFaaP.MFWSClient
 		/// <summary>
 		/// Flag to denote if operation is allowed to change name of the object.
 		/// </summary> 
-		public bool AllowNameChange;
-	}
+		public bool AllowNameChange { get; set; }
+    }
 
 	/// <summary>
 	/// Based on M-Files API.

--- a/MFaaP.MFWSClient/MFWSVaultAutomaticMetadataOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultAutomaticMetadataOperations.cs
@@ -30,7 +30,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for any metadata suggestions.</returns>
 		public async Task<List<PropertyValueSuggestion>> GetAutomaticMetadataAsync(AutomaticMetadataRequestInfo requestInfo,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/objects/automaticmetadata.aspx");
@@ -64,7 +64,7 @@ namespace MFaaP.MFWSClient
 			PropertyValue[] propertyValues = null,
 			string[] metadataSuggestionProviders = null,
 			string customData = null,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Build up the request.
 			var request = new AutomaticMetadataRequestInfo()
@@ -88,7 +88,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>Any metadata suggestions.</returns>
 		public List<PropertyValueSuggestion> GetAutomaticMetadata(AutomaticMetadataRequestInfo requestInfo,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetAutomaticMetadataAsync(requestInfo, token)
@@ -115,7 +115,7 @@ namespace MFaaP.MFWSClient
 			PropertyValue[] propertyValues = null,
 			string[] metadataSuggestionProviders = null,
 			string customData = null,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetAutomaticMetadataAsync(objectTypeId, objVer, temporaryFileIds, propertyValues, metadataSuggestionProviders, customData, token)
@@ -135,7 +135,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for any metadata suggestions.</returns>
 		public Task<List<PropertyValueSuggestion>> GetAutomaticMetadataForObjectAsync(ObjVer objVer,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -152,7 +152,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for any metadata suggestions.</returns>
 		public List<PropertyValueSuggestion> GetAutomaticMetadataForObject(ObjVer objVer,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -178,7 +178,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for any metadata suggestions.</returns>
 		public List<PropertyValueSuggestion> GetAutomaticMetadataForTemporaryFile(int temporaryFileId,
 			int objectTypeId = (int)MFBuiltInObjectType.MFBuiltInObjectTypeDocument,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetAutomaticMetadataAsync(objectTypeId: objectTypeId, temporaryFileIds: new int[] { temporaryFileId }, token: token)
@@ -196,7 +196,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for any metadata suggestions.</returns>
 		public Task<List<PropertyValueSuggestion>> GetAutomaticMetadataForTemporaryFileAsync(int temporaryFileId,
 			int objectTypeId = (int)MFBuiltInObjectType.MFBuiltInObjectTypeDocument,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetAutomaticMetadataAsync(objectTypeId: objectTypeId, temporaryFileIds: new int[] { temporaryFileId }, token: token);
@@ -211,7 +211,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for any metadata suggestions.</returns>
 		public List<PropertyValueSuggestion> GetAutomaticMetadataForTemporaryFiles(
 			int objectTypeId = (int)MFBuiltInObjectType.MFBuiltInObjectTypeDocument,
-			CancellationToken token = default(CancellationToken),
+			CancellationToken token = default,
 			params int[] temporaryFileIds)
 		{
 			// Execute the async method.
@@ -230,7 +230,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for any metadata suggestions.</returns>
 		public Task<List<PropertyValueSuggestion>> GetAutomaticMetadataForTemporaryFilesAsync(
 			int objectTypeId = (int)MFBuiltInObjectType.MFBuiltInObjectTypeDocument,
-			CancellationToken token = default(CancellationToken),
+			CancellationToken token = default,
 			params int[] temporaryFileIds)
 		{
 			// Execute the async method.

--- a/MFaaP.MFWSClient/MFWSVaultClassGroupOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultClassGroupOperations.cs
@@ -31,7 +31,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>All classes in the vault for the supplied object type.</returns>
         /// <remarks>This may be filtered by the user's permissions.</remarks>
-        public async Task<List<ClassGroup>> GetClassGroupsAsync(int objectTypeId, CancellationToken token = default(CancellationToken))
+        public async Task<List<ClassGroup>> GetClassGroupsAsync(int objectTypeId, CancellationToken token = default)
         {
             // Create the request.
             var request = new RestRequest($"/REST/structure/classes.aspx?objtype={objectTypeId}&bygroup=true");
@@ -51,7 +51,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>All classes in the vault for the supplied object type.</returns>
         /// <remarks>This may be filtered by the user's permissions.</remarks>
-        public List<ClassGroup> GetClassGroups(int objectTypeId, CancellationToken token = default(CancellationToken))
+        public List<ClassGroup> GetClassGroups(int objectTypeId, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetClassGroupsAsync(objectTypeId, token)

--- a/MFaaP.MFWSClient/MFWSVaultClassOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultClassOperations.cs
@@ -32,7 +32,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no classes have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<int> GetObjectClassIDByAliasAsync(string alias, CancellationToken token = default(CancellationToken))
+		public async Task<int> GetObjectClassIDByAliasAsync(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = await this.GetObjectClassIDsByAliasesAsync(token, aliases: new string[] { alias });
@@ -49,7 +49,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no object type have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<List<int>> GetObjectClassIDsByAliasesAsync(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public async Task<List<int>> GetObjectClassIDsByAliasesAsync(CancellationToken token = default, params string[] aliases)
 		{
 			// Sanity.
 			if (null == aliases)
@@ -78,7 +78,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no object type have the alias, or more than one does).</remarks>
-		public List<int> GetObjectClassIDsByAliases(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public List<int> GetObjectClassIDsByAliases(CancellationToken token = default, params string[] aliases)
 		{
 			// Execute the async method.
 			return this.GetObjectClassIDsByAliasesAsync(token, aliases)
@@ -95,7 +95,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no classes have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public int GetObjectClassIDByAlias(string alias, CancellationToken token = default(CancellationToken))
+		public int GetObjectClassIDByAlias(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = this.GetObjectClassIDsByAliases(token, aliases: new string[] { alias });
@@ -114,7 +114,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The class in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public async Task<ExtendedObjectClass> GetObjectClassAsync(int classId, bool includeTemplates = false, CancellationToken token = default(CancellationToken))
+		public async Task<ExtendedObjectClass> GetObjectClassAsync(int classId, bool includeTemplates = false, CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/structure/classes/{classId}.aspx");
@@ -141,7 +141,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The class in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public ExtendedObjectClass GetObjectClass(int classId, bool includeTemplates = false, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectClass GetObjectClass(int classId, bool includeTemplates = false, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetObjectClassAsync(classId, includeTemplates, token)
@@ -156,7 +156,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All classes in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public async Task<List<ExtendedObjectClass>> GetAllObjectClassesAsync(CancellationToken token = default(CancellationToken))
+		public async Task<List<ExtendedObjectClass>> GetAllObjectClassesAsync(CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/structure/classes.aspx");
@@ -175,7 +175,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All classes in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public List<ExtendedObjectClass> GetAllObjectClasses(CancellationToken token = default(CancellationToken))
+		public List<ExtendedObjectClass> GetAllObjectClasses(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetAllObjectClassesAsync(token)
@@ -191,7 +191,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All classes in the vault for the supplied object type.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public async Task<List<ExtendedObjectClass>> GetObjectClassesAsync(int objectTypeId, CancellationToken token = default(CancellationToken))
+		public async Task<List<ExtendedObjectClass>> GetObjectClassesAsync(int objectTypeId, CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/structure/classes.aspx?objtype={objectTypeId}");
@@ -211,7 +211,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All classes in the vault for the supplied object type.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public List<ExtendedObjectClass> GetObjectClasses(int objectTypeId, CancellationToken token = default(CancellationToken))
+		public List<ExtendedObjectClass> GetObjectClasses(int objectTypeId, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetObjectClassesAsync(objectTypeId, token)

--- a/MFaaP.MFWSClient/MFWSVaultExtensionAuthenticationOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultExtensionAuthenticationOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -31,7 +32,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task.</returns>
-		public async Task<List<RepositoryAuthenticationTarget>> GetExtensionAuthenticationTargetsAsync(CancellationToken token = default(CancellationToken))
+		public async Task<List<RepositoryAuthenticationTarget>> GetExtensionAuthenticationTargetsAsync(CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/repositories.aspx");
@@ -49,7 +50,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The authentication targets.</returns>
-		public List<RepositoryAuthenticationTarget> GetExtensionAuthenticationTargets(CancellationToken token = default(CancellationToken))
+		public List<RepositoryAuthenticationTarget> GetExtensionAuthenticationTargets(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetExtensionAuthenticationTargetsAsync(token)
@@ -72,7 +73,7 @@ namespace MFaaP.MFWSClient
 		public async Task<RepositoryAuthenticationStatus> LogInWithExtensionAuthenticationAsync(
 			string targetID,
 			RepositoryAuthentication authentication,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == targetID)
@@ -85,7 +86,7 @@ namespace MFaaP.MFWSClient
 				throw new ArgumentException("The authentication plugin configuration name must be provided.", nameof(authentication));
 
 			// Create the request.
-			var request = new RestRequest($"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
+			var request = new RestRequest($"/REST/repositories/{WebUtility.UrlEncode(targetID)}/session.aspx");
 
 			// If authentication token is a blank string, replace it with null.
 			// This is because the remote end tests against null.
@@ -113,7 +114,7 @@ namespace MFaaP.MFWSClient
 		public RepositoryAuthenticationStatus LogInWithExtensionAuthentication(
 			string targetID,
 			RepositoryAuthentication authentication,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.LogInWithExtensionAuthenticationAsync(targetID, authentication, token)
@@ -134,7 +135,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task.</returns>
 		public async Task LogOutWithExtensionAuthenticationAsync(
 			string targetID,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			if (null == targetID)
 				throw new ArgumentNullException(nameof(targetID));
@@ -142,7 +143,7 @@ namespace MFaaP.MFWSClient
 				throw new ArgumentException("The target cannot be null or empty.", nameof(targetID));
 
 			// Create the request.
-			var request = new RestRequest($"/REST/repositories/{HttpUtility.UrlEncode(targetID)}/session.aspx");
+			var request = new RestRequest($"/REST/repositories/{WebUtility.UrlEncode(targetID)}/session.aspx");
 
 			// Make the request and get the response.
 			await this.MFWSClient.Delete(request, token)
@@ -156,7 +157,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		public void LogOutWithExtensionAuthentication(
 			string targetID,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			this.LogOutWithExtensionAuthenticationAsync(targetID, token)

--- a/MFaaP.MFWSClient/MFWSVaultExtensionMethodOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultExtensionMethodOperations.cs
@@ -32,7 +32,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="input">The input (cannot be null) parameter.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response of the extension method, deserialised to an instance of <see paramref="TA"/>.</returns>
-		public async Task<TA> ExecuteVaultExtensionMethodAsync<TA, TB>(string extensionMethodName, TB input = null, CancellationToken token = default(CancellationToken))
+		public async Task<TA> ExecuteVaultExtensionMethodAsync<TA, TB>(string extensionMethodName, TB input = null, CancellationToken token = default)
 			where TA : new()
 			where TB : class
 		{
@@ -62,7 +62,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="input">The input (cannot be null) parameter.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response of the extension method, deserialised to an instance of <see paramref="TA"/>.</returns>
-		public TA ExecuteVaultExtensionMethod<TA, TB>(string extensionMethodName, TB input = null, CancellationToken token = default(CancellationToken))
+		public TA ExecuteVaultExtensionMethod<TA, TB>(string extensionMethodName, TB input = null, CancellationToken token = default)
 			where TA : new()
 			where TB : class
 		{
@@ -83,7 +83,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="input">The input (cannot be null) parameter.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response of the extension method.</returns>
-		public async Task<string> ExecuteVaultExtensionMethodAsync<TB>(string extensionMethodName, TB input = null, CancellationToken token = default(CancellationToken))
+		public async Task<string> ExecuteVaultExtensionMethodAsync<TB>(string extensionMethodName, TB input = null, CancellationToken token = default)
 			where TB : class
 		{
 			// Create the request.
@@ -111,7 +111,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="input">The input (cannot be null) parameter.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response of the extension method.</returns>
-		public string ExecuteVaultExtensionMethod<TB>(string extensionMethodName, TB input = null, CancellationToken token = default(CancellationToken))
+		public string ExecuteVaultExtensionMethod<TB>(string extensionMethodName, TB input = null, CancellationToken token = default)
 			where TB : class
 		{
 			// Execute the async method.
@@ -128,7 +128,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="input">The input parameter.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response of the extension method as a string.</returns>
-		public async Task<string> ExecuteVaultExtensionMethodAsync(string extensionMethodName, string input = null, CancellationToken token = default(CancellationToken))
+		public async Task<string> ExecuteVaultExtensionMethodAsync(string extensionMethodName, string input = null, CancellationToken token = default)
 		{
 
 			// Create the request.
@@ -138,7 +138,10 @@ namespace MFaaP.MFWSClient
 			if (null != input)
 			{
 				// We need to copy the default parameters if we are adding new ones (??).
-				request.Parameters.AddRange(this.MFWSClient.DefaultParameters);
+				foreach(var p in this.MFWSClient.DefaultParameters)
+				{
+					request.Parameters.AddParameter(p);
+				}
 
 				// Add the message body.
 				request.AddJsonBody(input);
@@ -159,7 +162,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="input">The input parameter.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The response of the extension method as a string.</returns>
-		public string ExecuteVaultExtensionMethod(string extensionMethodName, string input = null, CancellationToken token = default(CancellationToken))
+		public string ExecuteVaultExtensionMethod(string extensionMethodName, string input = null, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.ExecuteVaultExtensionMethodAsync(extensionMethodName, input, token)

--- a/MFaaP.MFWSClient/MFWSVaultExternalObjectOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultExternalObjectOperations.cs
@@ -29,7 +29,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="objectsToDemote">The Ids of the objects to demote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
-		public async Task<List<ExtendedObjectVersion>> DemoteObjectsAsync(CancellationToken token = default(CancellationToken), params ObjID[] objectsToDemote)
+		public async Task<List<ExtendedObjectVersion>> DemoteObjectsAsync(CancellationToken token = default, params ObjID[] objectsToDemote)
 		{
 			// Sanity.
 			if (null == objectsToDemote)
@@ -66,7 +66,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectsToDemote">The Ids of the objects to demote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The ObjectVersion, if it is visible to the user.</returns>
-		public List<ExtendedObjectVersion> DemoteObjects(CancellationToken token = default(CancellationToken), params ObjID[] objectsToDemote)
+		public List<ExtendedObjectVersion> DemoteObjects(CancellationToken token = default, params ObjID[] objectsToDemote)
 		{
 			// Execute the async method.
 			return this.DemoteObjectsAsync(token, objectsToDemote)
@@ -80,7 +80,7 @@ namespace MFaaP.MFWSClient
 		/// </summary>
 		/// <param name="objID">The Id of the object to demote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
-		public Task<List<ExtendedObjectVersion>> DemoteObjectAsync(ObjID objID, CancellationToken token = default(CancellationToken))
+		public Task<List<ExtendedObjectVersion>> DemoteObjectAsync(ObjID objID, CancellationToken token = default)
 		{
 			return this.DemoteObjectsAsync(token, objID);
 		}
@@ -91,7 +91,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objID">The Id of the object to demote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The ObjectVersion, if it is visible to the user.</returns>
-		public List<ExtendedObjectVersion> DemoteObject(ObjID objID, CancellationToken token = default(CancellationToken))
+		public List<ExtendedObjectVersion> DemoteObject(ObjID objID, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.DemoteObjectAsync(objID, token)
@@ -110,7 +110,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersionUpdateInformation">Information on the objects to promote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>The property values must be valid for the class, as they would if an object were being created.</remarks>
-		public Task<List<ExtendedObjectVersion>> PromoteObjectsAsync(CancellationToken token = default(CancellationToken), params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
+		public Task<List<ExtendedObjectVersion>> PromoteObjectsAsync(CancellationToken token = default, params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
 		{
 			// Use the "SetPropertiesOfMultipleObjects" method to perform this.
 			return this.MFWSClient.ObjectPropertyOperations.SetPropertiesOfMultipleObjectsAsync(
@@ -124,7 +124,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersionUpdateInformation">Information on the objects to promote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>The property values must be valid for the class, as they would if an object were being created.</remarks>
-		public List<ExtendedObjectVersion> PromoteObjects(CancellationToken token = default(CancellationToken), params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
+		public List<ExtendedObjectVersion> PromoteObjects(CancellationToken token = default, params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
 		{
 			// Execute the async method.
 			return this.PromoteObjectsAsync(token, objectVersionUpdateInformation)
@@ -140,7 +140,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyValues">The object's new properties.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>The property values must be valid for the class, as they would if an object were being created.</remarks>
-		public async Task<ExtendedObjectVersion> PromoteObjectAsync(ObjVer objVer, PropertyValue[] propertyValues, CancellationToken token = default(CancellationToken))
+		public async Task<ExtendedObjectVersion> PromoteObjectAsync(ObjVer objVer, PropertyValue[] propertyValues, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -168,7 +168,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyValues">The object's new properties.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>The property values must be valid for the class, as they would if an object were being created.</remarks>
-		public ExtendedObjectVersion PromoteObject(ObjVer objVer, PropertyValue[] propertyValues, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion PromoteObject(ObjVer objVer, PropertyValue[] propertyValues, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.PromoteObjectAsync(objVer, propertyValues, token)

--- a/MFaaP.MFWSClient/MFWSVaultObjectFileOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultObjectFileOperations.cs
@@ -29,7 +29,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="fileVer">The file to download.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public async Task<byte[]> DownloadFileAsync(ObjVer objVer, FileVer fileVer, CancellationToken token = default(CancellationToken))
+		public async Task<byte[]> DownloadFileAsync(ObjVer objVer, FileVer fileVer, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -62,7 +62,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="fileVer">The file to download.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public byte[] DownloadFile(ObjVer objVer, FileVer fileVer, CancellationToken token = default(CancellationToken))
+		public byte[] DownloadFile(ObjVer objVer, FileVer fileVer, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.DownloadFileAsync(objVer, fileVer, token)
@@ -80,7 +80,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersion">The version of the object, or null for the latest.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public Task<byte[]> DownloadFileAsync(int objectType, int objectId, int fileId, int? objectVersion = null, CancellationToken token = default(CancellationToken))
+		public Task<byte[]> DownloadFileAsync(int objectType, int objectId, int fileId, int? objectVersion = null, CancellationToken token = default)
         {
 			// Use the other overload.
 			return this.DownloadFileAsync(new ObjVer()
@@ -103,7 +103,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectVersion">The version of the object, or null for the latest.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The raw response from the HTTP request.</returns>
-        public byte[] DownloadFile(int objectType, int objectId, int fileId, int? objectVersion = null, CancellationToken token = default(CancellationToken))
+        public byte[] DownloadFile(int objectType, int objectId, int fileId, int? objectVersion = null, CancellationToken token = default)
         {
             // Execute the async method.
             return this.DownloadFileAsync(objectType, objectId, fileId, objectVersion, token)
@@ -120,7 +120,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="outputStream">The output stream for the response to be written to.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public async Task DownloadFileAsync(ObjVer objVer, FileVer fileVer, System.IO.Stream outputStream, CancellationToken token = default(CancellationToken))
+		public async Task DownloadFileAsync(ObjVer objVer, FileVer fileVer, System.IO.Stream outputStream, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -136,10 +136,10 @@ namespace MFaaP.MFWSClient
 			fileVer.GetUriParameters(out fileId, out fileVersionId);
 
 			// Build up the request.
-			var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/{objectVersionId}/files/{fileId}/content");
-
-			// Output the response to the given stream.
-			request.ResponseWriter = (responseStream) => responseStream.CopyTo(outputStream);
+			var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/{objectVersionId}/files/{fileId}/content")
+			{
+                ResponseWriter = (responseStream) => outputStream
+            };
 
 			// Execute the request.
 			await this.MFWSClient.Get(request, token)
@@ -154,7 +154,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="outputStream">The output stream for the response to be written to.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public void DownloadFile(ObjVer objVer, FileVer fileVer, System.IO.Stream outputStream, CancellationToken token = default(CancellationToken))
+		public void DownloadFile(ObjVer objVer, FileVer fileVer, System.IO.Stream outputStream, CancellationToken token = default)
 		{
 			// Execute the async method.
 			this.DownloadFileAsync(objVer, fileVer, outputStream, token)
@@ -173,7 +173,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersion">The version of the object, or null for the latest.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public Task DownloadFileAsync(int objectType, int objectId, int fileId, System.IO.Stream outputStream, int? objectVersion = null, CancellationToken token = default(CancellationToken))
+		public Task DownloadFileAsync(int objectType, int objectId, int fileId, System.IO.Stream outputStream, int? objectVersion = null, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.DownloadFileAsync(new ObjVer()
@@ -199,7 +199,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersion">The version of the object, or null for the latest.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public void DownloadFile(int objectType, int objectId, int fileId, System.IO.Stream outputStream, int? objectVersion = null, CancellationToken token = default(CancellationToken))
+		public void DownloadFile(int objectType, int objectId, int fileId, System.IO.Stream outputStream, int? objectVersion = null, CancellationToken token = default)
         {
             // Execute the async method.
             this.DownloadFileAsync(objectType, objectId, fileId, outputStream, objectVersion, token)
@@ -218,7 +218,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectVersion">The version of the object, or null for the latest.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>An awaitable task for the download process.</returns>
-        public Task DownloadFileAsync(int objectType, int objectId, int fileId, string outputFileName, int? objectVersion = null, CancellationToken token = default(CancellationToken))
+        public Task DownloadFileAsync(int objectType, int objectId, int fileId, string outputFileName, int? objectVersion = null, CancellationToken token = default)
         {
             // Create a FileInfo for the output.
             var outputFileInfo = new System.IO.FileInfo(outputFileName);
@@ -235,7 +235,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="outputFileName">The full path to the file to output to.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public void DownloadFile(ObjVer objVer, FileVer fileVer, string outputFileName, CancellationToken token = default(CancellationToken))
+		public void DownloadFile(ObjVer objVer, FileVer fileVer, string outputFileName, CancellationToken token = default)
 		{
 			// Create a FileInfo for the output.
 			var outputFileInfo = new System.IO.FileInfo(outputFileName);
@@ -257,7 +257,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersion">The version of the object, or null for the latest.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the download process.</returns>
-		public void DownloadFile(int objectType, int objectId, int fileId, string outputFileName, int? objectVersion = null, CancellationToken token = default(CancellationToken))
+		public void DownloadFile(int objectType, int objectId, int fileId, string outputFileName, int? objectVersion = null, CancellationToken token = default)
         {
             // Execute the async method.
             this.DownloadFileAsync(objectType, objectId, fileId, outputFileName, objectVersion, token)
@@ -277,7 +277,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>An awaitable task for the download process.</returns>
         public Task DownloadFileAsync(int objectType, int objectId, int fileId, System.IO.FileInfo outputFileInfo, int? objectVersion = null,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Sanity.
             if (null == outputFileInfo)
@@ -306,7 +306,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>An awaitable task for the download process.</returns>
         public void DownloadFile(int objectType, int objectId, int fileId, System.IO.FileInfo outputFileInfo, int? objectVersion = null,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Execute the async method.
             this.DownloadFileAsync(objectType, objectId, fileId, outputFileInfo, objectVersion, token)
@@ -324,7 +324,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the download process.</returns>
 		public async Task DownloadFileAsync(ObjVer objVer, FileVer fileVer, System.IO.FileInfo outputFileInfo,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == outputFileInfo)
@@ -351,7 +351,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="outputFileInfo">The file to output the content to (will be overwritten if exists).</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The raw response from the HTTP request.</returns>
-		public void DownloadFile(ObjVer objVer, FileVer fileVer, System.IO.FileInfo outputFileInfo, CancellationToken token = default(CancellationToken))
+		public void DownloadFile(ObjVer objVer, FileVer fileVer, System.IO.FileInfo outputFileInfo, CancellationToken token = default)
 		{
 			// Execute the async method.
 			this.DownloadFileAsync(objVer, fileVer, outputFileInfo, token)
@@ -459,7 +459,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectVersion">The version of the object, or null for the latest.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The updated object version.</returns>
-        public async Task<ExtendedObjectVersion> AddFilesAsync(int objectType, int objectId, int? objectVersion = null, CancellationToken token = default(CancellationToken), params FileInfo[] files)
+        public async Task<ExtendedObjectVersion> AddFilesAsync(int objectType, int objectId, int? objectVersion = null, CancellationToken token = default, params FileInfo[] files)
         {
             // Sanity.
             if (null == files)
@@ -507,7 +507,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectVersion">The version of the object, or null for the latest.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The updated object version.</returns>
-        public ExtendedObjectVersion AddFiles(int objectType, int objectId, int? objectVersion = null, CancellationToken token = default(CancellationToken), params FileInfo[] files)
+        public ExtendedObjectVersion AddFiles(int objectType, int objectId, int? objectVersion = null, CancellationToken token = default, params FileInfo[] files)
         {
             // Execute the async method.
             return this.AddFilesAsync(objectType, objectId, objectVersion, token, files)
@@ -527,7 +527,7 @@ namespace MFaaP.MFWSClient
         public Task<ExtendedObjectVersion> AddFilesAsync(int objectType, int objectId, int? objectVersion = null, params FileInfo[] files)
         {
             // Execute the other overload.
-            return this.AddFilesAsync(objectType, objectId, objectVersion, default(CancellationToken), files);
+            return this.AddFilesAsync(objectType, objectId, objectVersion, default, files);
         }
 
         /// <summary>
@@ -541,7 +541,7 @@ namespace MFaaP.MFWSClient
         public ExtendedObjectVersion AddFiles(int objectType, int objectId, int? objectVersion = null, params FileInfo[] files)
         {
             // Execute the other overload.
-            return this.AddFiles(objectType, objectId, objectVersion, default(CancellationToken), files);
+            return this.AddFiles(objectType, objectId, objectVersion, default, files);
         }
 
         /// <summary>
@@ -557,7 +557,7 @@ namespace MFaaP.MFWSClient
                 throw new ArgumentNullException(nameof(objId));
 
             // Execute the other overload.
-            return this.AddFilesAsync(objId.Type, objId.ID, objectVersion: null, token: default(CancellationToken), files: files);
+            return this.AddFilesAsync(objId.Type, objId.ID, objectVersion: null, token: default, files: files);
         }
 
         /// <summary>
@@ -573,7 +573,7 @@ namespace MFaaP.MFWSClient
                 throw new ArgumentNullException(nameof(objId));
 
             // Execute the other overload.
-            return this.AddFiles(objId.Type, objId.ID, objectVersion: null, token: default(CancellationToken), files: files);
+            return this.AddFiles(objId.Type, objId.ID, objectVersion: null, token: default, files: files);
         }
 
         /// <summary>
@@ -583,7 +583,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <param name="files">The files to attach.</param>
         /// <returns>The updated object version.</returns>
-        public Task<ExtendedObjectVersion> AddFilesAsync(ObjID objId, CancellationToken token = default(CancellationToken), params FileInfo[] files)
+        public Task<ExtendedObjectVersion> AddFilesAsync(ObjID objId, CancellationToken token = default, params FileInfo[] files)
         {
             // Sanity.
             if (null == objId)
@@ -600,7 +600,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <param name="files">The files to attach.</param>
         /// <returns>The updated object version.</returns>
-        public ExtendedObjectVersion AddFiles(ObjID objId, CancellationToken token = default(CancellationToken), params FileInfo[] files)
+        public ExtendedObjectVersion AddFiles(ObjID objId, CancellationToken token = default, params FileInfo[] files)
         {
             // Sanity.
             if (null == objId)
@@ -623,7 +623,7 @@ namespace MFaaP.MFWSClient
                 throw new ArgumentNullException(nameof(objVer));
 
             // Execute the other overload.
-            return this.AddFilesAsync(objVer.Type, objVer.ID, objVer.Version, default(CancellationToken), files);
+            return this.AddFilesAsync(objVer.Type, objVer.ID, objVer.Version, default, files);
         }
 
         /// <summary>
@@ -639,7 +639,7 @@ namespace MFaaP.MFWSClient
                 throw new ArgumentNullException(nameof(objVer));
 
             // Execute the other overload.
-            return this.AddFiles(objVer.Type, objVer.ID, objVer.Version, default(CancellationToken), files);
+            return this.AddFiles(objVer.Type, objVer.ID, objVer.Version, default, files);
         }
 
         /// <summary>
@@ -649,7 +649,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <param name="files">The files to attach.</param>
         /// <returns>The updated object version.</returns>
-        public Task<ExtendedObjectVersion> AddFilesAsync(ObjVer objVer, CancellationToken token = default(CancellationToken), params FileInfo[] files)
+        public Task<ExtendedObjectVersion> AddFilesAsync(ObjVer objVer, CancellationToken token = default, params FileInfo[] files)
         {
             // Sanity.
             if (null == objVer)
@@ -666,7 +666,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <param name="files">The files to attach.</param>
 		/// <returns>The updated object version.</returns>
-		public ExtendedObjectVersion AddFiles(ObjVer objVer, CancellationToken token = default(CancellationToken), params FileInfo[] files)
+		public ExtendedObjectVersion AddFiles(ObjVer objVer, CancellationToken token = default, params FileInfo[] files)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -684,7 +684,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="filePath">The path to the file to upload in its replacement.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The updated object version.</returns>
-		public async Task<ExtendedObjectVersion> UploadFileAsync(ObjVer objVer, FileVer fileVer, string filePath, CancellationToken token = default(CancellationToken))
+		public async Task<ExtendedObjectVersion> UploadFileAsync(ObjVer objVer, FileVer fileVer, string filePath, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -732,7 +732,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="filePath">The path to the file to upload in its replacement.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The updated object version.</returns>
-		public ExtendedObjectVersion UploadFile(ObjVer objVer, FileVer fileVer, string filePath, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion UploadFile(ObjVer objVer, FileVer fileVer, string filePath, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.UploadFileAsync(objVer, fileVer, filePath, token)
@@ -762,7 +762,7 @@ namespace MFaaP.MFWSClient
 			string newFileName,
 			int? objectVersion = null,
 			int? fileVersion = null,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
         {
 			// Create the version strings to be used for the uri segment.
 			var objectVersionString = objectVersion?.ToString() ?? "latest";
@@ -801,7 +801,7 @@ namespace MFaaP.MFWSClient
 			string newFileName,
 			int? objectVersion = null,
 			int? fileVersion = null,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.RenameFileAsync(objectType, objectId, fileId, newFileName, objectVersion, fileVersion, token)
@@ -822,7 +822,7 @@ namespace MFaaP.MFWSClient
 		public ObjectVersion RenameFile(ObjID objId,
 			FileVer fileVer,
 			string newFileName,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objId)
@@ -849,7 +849,7 @@ namespace MFaaP.MFWSClient
 		public ObjectVersion RenameFile(ObjVer objVer,
 			FileVer fileVer,
 			string newFileName,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -934,7 +934,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>Information on the upload.</returns>
 		/// <remarks>THIS METHOD IS NOT DOCUMENTED SO DO NOT USE IN PRODUCTION ENVIRONMENTS.</remarks>
-		public UploadInfo UploadTemporaryFileBlockBegin(FileInfo fileInfo, CancellationToken token = default(CancellationToken))
+		public UploadInfo UploadTemporaryFileBlockBegin(FileInfo fileInfo, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.UploadTemporaryFileBlockBeginAsync(fileInfo, token)
@@ -959,7 +959,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>Information on the upload.</returns>
 		/// <remarks>THIS METHOD IS NOT DOCUMENTED SO DO NOT USE IN PRODUCTION ENVIRONMENTS.</remarks>
 		public async Task<UploadInfo> UploadTemporaryFileBlockAsync(int uploadId, long totalSizeInBytes, long offset, byte[] block,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/files/upload/{uploadId}.aspx");
@@ -1000,7 +1000,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>Information on the upload.</returns>
 		/// <remarks>THIS METHOD IS NOT DOCUMENTED SO DO NOT USE IN PRODUCTION ENVIRONMENTS.</remarks>
 		public UploadInfo UploadTemporaryFileBlock(int uploadId, long totalSizeInBytes, long offset, byte[] block,
-			CancellationToken token = default(CancellationToken))
+			CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.UploadTemporaryFileBlockAsync(uploadId, totalSizeInBytes, offset, block, token)
@@ -1021,7 +1021,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>Information on the upload.</returns>
 		/// <remarks>THIS METHOD IS NOT DOCUMENTED SO DO NOT USE IN PRODUCTION ENVIRONMENTS.</remarks>
-		public async Task<UploadInfo> UploadTemporaryFileCommitAsync(UploadInfo uploadInfo, CancellationToken token = default(CancellationToken))
+		public async Task<UploadInfo> UploadTemporaryFileCommitAsync(UploadInfo uploadInfo, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == uploadInfo)
@@ -1048,7 +1048,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>Information on the upload.</returns>
 		/// <remarks>THIS METHOD IS NOT DOCUMENTED SO DO NOT USE IN PRODUCTION ENVIRONMENTS.</remarks>
-		public UploadInfo UploadTemporaryFileCommit(UploadInfo uploadInfo, CancellationToken token = default(CancellationToken))
+		public UploadInfo UploadTemporaryFileCommit(UploadInfo uploadInfo, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.UploadTemporaryFileCommitAsync(uploadInfo, token)
@@ -1168,7 +1168,7 @@ namespace MFaaP.MFWSClient
 		/// <remarks>THIS METHOD IS NOT DOCUMENTED SO DO NOT USE IN PRODUCTION ENVIRONMENTS.</remarks>
 		public UploadInfo UploadTemporaryFileInBlocks(
 			FileInfo fileToUpload,
-			CancellationToken token = default(CancellationToken),
+			CancellationToken token = default,
 			int blockSize = 1024 * 1024 * 2)
 		{
 			// Execute the async method.
@@ -1189,7 +1189,7 @@ namespace MFaaP.MFWSClient
 		public UploadInfo UploadTemporaryFileInBlocks(
 			string newFileName,
 			Stream fileToUpload,
-			CancellationToken token = default(CancellationToken),
+			CancellationToken token = default,
 			int blockSize = 1024 * 1024 * 2)
 		{
 			// Execute the async method.
@@ -1204,14 +1204,14 @@ namespace MFaaP.MFWSClient
 		#endregion
 
 		#region Removing files
-		public ExtendedObjectVersion RemoveFile(ObjVer objVer, FileVer fileVer, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion RemoveFile(ObjVer objVer, FileVer fileVer, CancellationToken token = default)
         {
 			return this.RemoveFileAsync(objVer, fileVer)
 				.ConfigureAwait(false)
 				.GetAwaiter()
 				.GetResult();
 		}
-		public async Task<ExtendedObjectVersion> RemoveFileAsync(ObjVer objVer, FileVer fileVer, CancellationToken token = default(CancellationToken))
+		public async Task<ExtendedObjectVersion> RemoveFileAsync(ObjVer objVer, FileVer fileVer, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -1228,7 +1228,7 @@ namespace MFaaP.MFWSClient
 
 			// Build up the request.
 			var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/{objectVersionId}/files/{fileId}");
-			request.Method = Method.DELETE;
+			request.Method = Method.Delete;
 
 			// Execute the request.
 			var response = await this.MFWSClient.Delete<ExtendedObjectVersion>(request, token)

--- a/MFaaP.MFWSClient/MFWSVaultObjectOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultObjectOperations.cs
@@ -34,7 +34,7 @@ namespace MFaaP.MFWSClient
         /// <returns>Information on the renamed object.</returns>
         public async Task<ObjectVersion> RenameObjectAsync(ObjVer objVer,
             string newObjectName,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Sanity.
             if (null == objVer)
@@ -67,7 +67,7 @@ namespace MFaaP.MFWSClient
         public Task<ObjectVersion> RenameObjectAsync(
             ObjID objId,
             string newObjectName,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             return this.RenameObjectAsync(new ObjVer()
             {
@@ -91,7 +91,7 @@ namespace MFaaP.MFWSClient
         /// <remarks>ref: http://developer.m-files.com/APIs/REST-API/Reference/resources/objects/type/objectid/version/title/ </remarks>
         public ObjectVersion RenameObject(ObjVer objVer,
             string newObjectName,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Execute the async method.
             return this.RenameObjectAsync(objVer, newObjectName, token)
@@ -110,7 +110,7 @@ namespace MFaaP.MFWSClient
         public ObjectVersion RenameObject(
             ObjID objId,
             string newObjectName,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Use the other overload.
             return this.RenameObject(new ObjVer()
@@ -135,7 +135,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is visible to the user.</returns>
-        public async Task<ExtendedObjectVersion> GetLatestObjectVersionAndPropertiesAsync(ObjID objId, CancellationToken token = default(CancellationToken))
+        public async Task<ExtendedObjectVersion> GetLatestObjectVersionAndPropertiesAsync(ObjID objId, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -165,7 +165,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is visible to the user.</returns>
-        public Task<ExtendedObjectVersion> GetLatestObjectVersionAndPropertiesAsync(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public Task<ExtendedObjectVersion> GetLatestObjectVersionAndPropertiesAsync(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the other overload.
             return this.GetLatestObjectVersionAndPropertiesAsync(new ObjID()
@@ -181,7 +181,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is visible to the user.</returns>
-        public ExtendedObjectVersion GetLatestObjectVersionAndProperties(ObjID objId, CancellationToken token = default(CancellationToken))
+        public ExtendedObjectVersion GetLatestObjectVersionAndProperties(ObjID objId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetLatestObjectVersionAndPropertiesAsync(objId, token)
@@ -197,7 +197,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The ID of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is visible to the user.</returns>
-        public ExtendedObjectVersion GetLatestObjectVersionAndProperties(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public ExtendedObjectVersion GetLatestObjectVersionAndProperties(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the other overload.
             return this.GetLatestObjectVersionAndProperties(new ObjID()
@@ -218,7 +218,7 @@ namespace MFaaP.MFWSClient
         /// <param name="creationInfo">The creation information for the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>Information on the created object.</returns>
-        public async Task<ObjectVersion> CreateNewObjectAsync(int objectTypeId, ObjectCreationInfo creationInfo, CancellationToken token = default(CancellationToken))
+        public async Task<ObjectVersion> CreateNewObjectAsync(int objectTypeId, ObjectCreationInfo creationInfo, CancellationToken token = default)
         {
             // Sanity.
             if (null == creationInfo)
@@ -262,7 +262,7 @@ namespace MFaaP.MFWSClient
         /// <param name="creationInfo">The creation information for the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>Information on the created object.</returns>
-        public ObjectVersion CreateNewObject(int objectTypeId, ObjectCreationInfo creationInfo, CancellationToken token = default(CancellationToken))
+        public ObjectVersion CreateNewObject(int objectTypeId, ObjectCreationInfo creationInfo, CancellationToken token = default)
         {
             // Execute the async method.
             return this.CreateNewObjectAsync(objectTypeId, creationInfo, token)
@@ -285,7 +285,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
         public Task<ObjectVersion> SetCheckoutStatusAsync(int objectTypeId, int objectId, MFCheckOutStatus status, int? version = null,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Sanity.
             if (objectTypeId < 0)
@@ -311,7 +311,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
         public ObjectVersion SetCheckoutStatus(int objectTypeId, int objectId, MFCheckOutStatus status, int? version = null,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Execute the async method.
             return this.SetCheckoutStatusAsync(objectTypeId, objectId, status, version, token)
@@ -329,7 +329,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
         public Task<ObjectVersion> SetCheckoutStatusAsync(ObjID objId, MFCheckOutStatus status, int? version = null,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -359,7 +359,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
         public ObjectVersion SetCheckoutStatus(ObjID objId, MFCheckOutStatus status, int? version = null,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Execute the async method.
             return this.SetCheckoutStatusAsync(objId, status, version, token)
@@ -375,7 +375,7 @@ namespace MFaaP.MFWSClient
         /// <param name="status">The checkout status.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public async Task<ObjectVersion> SetCheckoutStatusAsync(ObjVer objVer, MFCheckOutStatus status, CancellationToken token = default(CancellationToken))
+        public async Task<ObjectVersion> SetCheckoutStatusAsync(ObjVer objVer, MFCheckOutStatus status, CancellationToken token = default)
         {
             // Sanity.
             if (null == objVer)
@@ -405,7 +405,7 @@ namespace MFaaP.MFWSClient
         /// <param name="status">The checkout status.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public ObjectVersion SetCheckoutStatus(ObjVer objVer, MFCheckOutStatus status, CancellationToken token = default(CancellationToken))
+        public ObjectVersion SetCheckoutStatus(ObjVer objVer, MFCheckOutStatus status, CancellationToken token = default)
         {
             // Execute the async method.
             return this.SetCheckoutStatusAsync(objVer, status, token)
@@ -422,7 +422,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<MFCheckOutStatus?> GetCheckoutStatusAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+        public Task<MFCheckOutStatus?> GetCheckoutStatusAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
         {
 
             // Sanity.
@@ -459,7 +459,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public MFCheckOutStatus? GetCheckoutStatus(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+        public MFCheckOutStatus? GetCheckoutStatus(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetCheckoutStatusAsync(objectTypeId, objectId, version, token)
@@ -475,7 +475,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<MFCheckOutStatus?> GetCheckoutStatusAsync(ObjID objId, int? version = null, CancellationToken token = default(CancellationToken))
+        public Task<MFCheckOutStatus?> GetCheckoutStatusAsync(ObjID objId, int? version = null, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -501,7 +501,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public MFCheckOutStatus? GetCheckoutStatus(ObjID objId, int? version = null, CancellationToken token = default(CancellationToken))
+        public MFCheckOutStatus? GetCheckoutStatus(ObjID objId, int? version = null, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetCheckoutStatusAsync(objId, version, token)
@@ -516,7 +516,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id and version of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public async Task<MFCheckOutStatus?> GetCheckoutStatusAsync(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public async Task<MFCheckOutStatus?> GetCheckoutStatusAsync(ObjVer objVer, CancellationToken token = default)
         {
             // Sanity.
             if (null == objVer)
@@ -547,7 +547,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id and version of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public MFCheckOutStatus? GetCheckoutStatus(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public MFCheckOutStatus? GetCheckoutStatus(ObjVer objVer, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetCheckoutStatusAsync(objVer, token)
@@ -564,7 +564,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<ObjectVersion> CheckOutAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> CheckOutAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
         {
             return this.SetCheckoutStatusAsync(objectTypeId, objectId, MFCheckOutStatus.CheckedOutToMe, version, token);
         }
@@ -577,7 +577,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public ObjectVersion CheckOut(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+        public ObjectVersion CheckOut(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
         {
             // Execute the async method.
             return this.CheckOutAsync(objectTypeId, objectId, version, token)
@@ -593,7 +593,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public ObjectVersion CheckOut(ObjID objId, int? version = null, CancellationToken token = default(CancellationToken))
+        public ObjectVersion CheckOut(ObjID objId, int? version = null, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -612,7 +612,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id and version of the object to check out.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<ObjectVersion> CheckOutAsync(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> CheckOutAsync(ObjVer objVer, CancellationToken token = default)
         {
             return this.SetCheckoutStatusAsync(objVer, MFCheckOutStatus.CheckedOutToMe, token);
         }
@@ -623,7 +623,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id and version of the object to check out.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public ObjectVersion CheckOut(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public ObjectVersion CheckOut(ObjVer objVer, CancellationToken token = default)
         {
             // Sanity.
             if (null == objVer)
@@ -643,7 +643,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<ObjectVersion> CheckOutAsync(ObjID objId, int? version = null, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> CheckOutAsync(ObjID objId, int? version = null, CancellationToken token = default)
         {
             return this.SetCheckoutStatusAsync(objId, MFCheckOutStatus.CheckedOutToMe, version, token);
         }
@@ -656,7 +656,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<ObjectVersion> CheckInAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> CheckInAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
         {
             return this.SetCheckoutStatusAsync(objectTypeId, objectId, MFCheckOutStatus.CheckedIn, version, token);
         }
@@ -669,7 +669,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public ObjectVersion CheckIn(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+        public ObjectVersion CheckIn(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
         {
             // Execute the async method.
             return this.CheckInAsync(objectTypeId, objectId, version, token)
@@ -684,7 +684,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id and version of the object to check out.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<ObjectVersion> CheckInAsync(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> CheckInAsync(ObjVer objVer, CancellationToken token = default)
         {
             // Sanity.
             if (null == objVer)
@@ -699,7 +699,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id and version of the object to check out.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public ObjectVersion CheckIn(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public ObjectVersion CheckIn(ObjVer objVer, CancellationToken token = default)
         {
             // Sanity.
             if (null == objVer)
@@ -719,7 +719,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<ObjectVersion> CheckInAsync(ObjID objId, int? version = null, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> CheckInAsync(ObjID objId, int? version = null, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -735,7 +735,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version (or null for latest).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public ObjectVersion CheckIn(ObjID objId, int? version = null, CancellationToken token = default(CancellationToken))
+        public ObjectVersion CheckIn(ObjID objId, int? version = null, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -755,7 +755,7 @@ namespace MFaaP.MFWSClient
         /// <param name="force">If true, will undo checkout even if this object isn't checked out to this user on this machine (subject to user rights).</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The new ObjectVersion information if it is still visible to the user.</returns>
-        protected async Task<ObjectVersion> UndoCheckoutAsync(ObjVer objVer, bool force, CancellationToken token = default(CancellationToken))
+        protected async Task<ObjectVersion> UndoCheckoutAsync(ObjVer objVer, bool force, CancellationToken token = default)
         {
 
             // Sanity.
@@ -764,7 +764,7 @@ namespace MFaaP.MFWSClient
 
             // Create the request.
             var request = new RestRequest($"/REST/objects/{objVer.Type}/{objVer.ID}/{objVer.Version}?force={force.ToString().ToLower()}");
-            request.Method = Method.DELETE;
+            request.Method = Method.Delete;
 
             // Make the request and get the response.
             var response = await this.MFWSClient.Delete<ObjectVersion>(request, token)
@@ -780,7 +780,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id, type and version of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The new ObjectVersion information if it is still visible to the user.</returns>
-        public Task<ObjectVersion> UndoCheckoutAsync(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> UndoCheckoutAsync(ObjVer objVer, CancellationToken token = default)
         {
             // Use the other overload.
             return this.UndoCheckoutAsync(objVer, force: false, token: token);
@@ -794,7 +794,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The new ObjectVersion information if it is still visible to the user.</returns>
-        public Task<ObjectVersion> UndoCheckoutAsync(int objectTypeId, int objectId, int version, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> UndoCheckoutAsync(int objectTypeId, int objectId, int version, CancellationToken token = default)
         {
             // Use the other overload.
             return this.UndoCheckoutAsync(new ObjVer()
@@ -817,7 +817,7 @@ namespace MFaaP.MFWSClient
             int objectTypeId,
             int objectId,
             int version,
-            CancellationToken token = default(CancellationToken))
+            CancellationToken token = default)
         {
             // Execute the async method.
             return this.UndoCheckoutAsync(new ObjVer()
@@ -837,7 +837,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id, type and version of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The new ObjectVersion information if it is still visible to the user.</returns>
-        public ObjectVersion UndoCheckout(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public ObjectVersion UndoCheckout(ObjVer objVer, CancellationToken token = default)
         {
             // Sanity.
             if (null == objVer)
@@ -857,7 +857,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objVer">The Id, type and version of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The new ObjectVersion information if it is still visible to the user.</returns>
-        public Task<ObjectVersion> ForceUndoCheckoutAsync(ObjVer objVer, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> ForceUndoCheckoutAsync(ObjVer objVer, CancellationToken token = default)
         {
             // Use the other overload.
             return this.UndoCheckoutAsync(objVer, force: true, token: token);
@@ -872,7 +872,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The new ObjectVersion information if it is still visible to the user.</returns>
-        public Task<ObjectVersion> ForceUndoCheckoutAsync(int objectTypeId, int objectId, int version, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> ForceUndoCheckoutAsync(int objectTypeId, int objectId, int version, CancellationToken token = default)
         {
             // Use the other overload.
             return this.ForceUndoCheckoutAsync(new ObjVer()
@@ -892,7 +892,7 @@ namespace MFaaP.MFWSClient
         /// <param name="version">The version.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The new ObjectVersion information if it is still visible to the user.</returns>
-        public ObjectVersion ForceUndoCheckout(int objectTypeId, int objectId, int version, CancellationToken token = default(CancellationToken))
+        public ObjectVersion ForceUndoCheckout(int objectTypeId, int objectId, int version, CancellationToken token = default)
         {
             // Execute the async method.
             return this.ForceUndoCheckoutAsync(objectTypeId, objectId, version, token)
@@ -912,7 +912,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public Task<bool?> GetDeletedStatusAsync(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public Task<bool?> GetDeletedStatusAsync(int objectTypeId, int objectId, CancellationToken token = default)
         {
 
             // Sanity.
@@ -936,7 +936,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public bool? GetDeletedStatus(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public bool? GetDeletedStatus(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetDeletedStatusAsync(objectTypeId, objectId, token)
@@ -951,7 +951,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public async Task<bool?> GetDeletedStatusAsync(ObjID objId, CancellationToken token = default(CancellationToken))
+        public async Task<bool?> GetDeletedStatusAsync(ObjID objId, CancellationToken token = default)
         {
 
             // Sanity.
@@ -980,7 +980,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A representation of the checked-in object version/</returns>
-        public bool? GetDeletedStatus(ObjID objId, CancellationToken token = default(CancellationToken))
+        public bool? GetDeletedStatus(ObjID objId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetDeletedStatusAsync(objId, token)
@@ -999,7 +999,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public async Task<ObjectVersion> UndeleteObjectAsync(ObjID objId, CancellationToken token = default(CancellationToken))
+        public async Task<ObjectVersion> UndeleteObjectAsync(ObjID objId, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -1012,7 +1012,7 @@ namespace MFaaP.MFWSClient
 
             // Create the request.
             var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/deleted");
-            request.Method = Method.PUT;
+            request.Method = Method.Put;
 
             // Add the body.
             request.AddJsonBody(new PrimitiveType<bool>() { Value = false });
@@ -1032,7 +1032,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public Task<ObjectVersion> UndeleteObjectAsync(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> UndeleteObjectAsync(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Sanity.
             if (objectTypeId < 0)
@@ -1055,7 +1055,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public ObjectVersion UndeleteObject(ObjID objId, CancellationToken token = default(CancellationToken))
+        public ObjectVersion UndeleteObject(ObjID objId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.UndeleteObjectAsync(objId, token)
@@ -1071,7 +1071,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public ObjectVersion UndeleteObject(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public ObjectVersion UndeleteObject(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.UndeleteObjectAsync(new ObjID()
@@ -1094,7 +1094,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public async Task<ObjectVersion> DeleteObjectAsync(ObjID objId, CancellationToken token = default(CancellationToken))
+        public async Task<ObjectVersion> DeleteObjectAsync(ObjID objId, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -1107,7 +1107,7 @@ namespace MFaaP.MFWSClient
 
             // Create the request.
             var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/deleted");
-            request.Method = Method.PUT;
+            request.Method = Method.Put;
 
             // Add the body.
             request.AddJsonBody(new PrimitiveType<bool>() { Value = true });
@@ -1127,7 +1127,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public Task<ObjectVersion> DeleteObjectAsync(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public Task<ObjectVersion> DeleteObjectAsync(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Sanity.
             if (objectTypeId < 0)
@@ -1149,7 +1149,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public ObjectVersion DeleteObject(ObjID objId, CancellationToken token = default(CancellationToken))
+        public ObjectVersion DeleteObject(ObjID objId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.DeleteObjectAsync(objId, token)
@@ -1165,7 +1165,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The ObjectVersion, if it is still visible to the user.</returns>
-        public ObjectVersion DeleteObject(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public ObjectVersion DeleteObject(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.DeleteObjectAsync(new ObjID()
@@ -1192,7 +1192,7 @@ namespace MFaaP.MFWSClient
         /// <returns>True if 204 was received from the server.</returns>
         /// <remarks>Unlike the COM API method (https://www.m-files.com/api/documentation/latest/index.html#MFilesAPI~VaultObjectOperations~DestroyObject.html),
         /// the REST API only supports destroying all versions.</remarks>
-        public async Task<bool> DestroyObjectAsync(ObjID objId, bool destroyAllVersions, int version, CancellationToken token = default(CancellationToken))
+        public async Task<bool> DestroyObjectAsync(ObjID objId, bool destroyAllVersions, int version, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -1204,7 +1204,7 @@ namespace MFaaP.MFWSClient
 
             // Create the request.
             var request = new RestRequest($"/REST/objects/{objId.Type}/{objId.ID}/latest?allVersions=true");
-            request.Method = Method.DELETE;
+            request.Method = Method.Delete;
 
             // Make the request and get the response.
             var response = await this.MFWSClient.Delete<ObjectVersion>(request, token)
@@ -1224,7 +1224,7 @@ namespace MFaaP.MFWSClient
         /// <returns>True if 204 was received from the server.</returns>
         /// <remarks>Unlike the COM API method (https://www.m-files.com/api/documentation/latest/index.html#MFilesAPI~VaultObjectOperations~DestroyObject.html),
         /// the REST API only supports destroying all versions.</remarks>
-        public Task<bool> DestroyObjectAsync(int objectTypeId, int objectId, bool destroyAllVersions, int version, CancellationToken token = default(CancellationToken))
+        public Task<bool> DestroyObjectAsync(int objectTypeId, int objectId, bool destroyAllVersions, int version, CancellationToken token = default)
         {
             // Sanity.
             if (objectTypeId < 0)
@@ -1253,7 +1253,7 @@ namespace MFaaP.MFWSClient
         /// <returns>True if 204 was received from the server.</returns>
         /// <remarks>Unlike the COM API method (https://www.m-files.com/api/documentation/latest/index.html#MFilesAPI~VaultObjectOperations~DestroyObject.html),
         /// the REST API only supports destroying all versions.</remarks>
-        public bool DestroyObject(ObjID objId, bool destroyAllVersions, int version, CancellationToken token = default(CancellationToken))
+        public bool DestroyObject(ObjID objId, bool destroyAllVersions, int version, CancellationToken token = default)
         {
             // Execute the async method.
             return this.DestroyObjectAsync(objId, destroyAllVersions, version, token)
@@ -1273,7 +1273,7 @@ namespace MFaaP.MFWSClient
         /// <returns>True if 204 was received from the server.</returns>
         /// <remarks>Unlike the COM API method (https://www.m-files.com/api/documentation/latest/index.html#MFilesAPI~VaultObjectOperations~DestroyObject.html),
         /// the REST API only supports destroying all versions.</remarks>
-        public bool DestroyObject(int objectTypeId, int objectId, bool destroyAllVersions, int version, CancellationToken token = default(CancellationToken))
+        public bool DestroyObject(int objectTypeId, int objectId, bool destroyAllVersions, int version, CancellationToken token = default)
         {
             // Execute the async method.
             return this.DestroyObjectAsync(new ObjID()
@@ -1298,7 +1298,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A collection of <see cref="ObjectVersion"/>s representing the object history.</returns>
         /// <remarks>Note that not all versions may be shown: http://www.m-files.com/mfws/resources/objects/type/objectid/history.html</remarks>
-        public Task<List<ObjectVersion>> GetHistoryAsync(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public Task<List<ObjectVersion>> GetHistoryAsync(int objectTypeId, int objectId, CancellationToken token = default)
         {
             return this.GetHistoryAsync(new ObjID()
             {
@@ -1316,7 +1316,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A collection of <see cref="ObjectVersion"/>s representing the object history.</returns>
         /// <remarks>Note that not all versions may be shown: http://www.m-files.com/mfws/resources/objects/type/objectid/history.html</remarks>
-        public List<ObjectVersion> GetHistory(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public List<ObjectVersion> GetHistory(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetHistoryAsync(objectTypeId, objectId, token)
@@ -1332,7 +1332,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A collection of <see cref="ObjectVersion"/>s representing the object history.</returns>
         /// <remarks>Note that not all versions may be shown: http://www.m-files.com/mfws/resources/objects/type/objectid/history.html</remarks>
-        public async Task<List<ObjectVersion>> GetHistoryAsync(ObjID objID, CancellationToken token = default(CancellationToken))
+        public async Task<List<ObjectVersion>> GetHistoryAsync(ObjID objID, CancellationToken token = default)
         {
             // Sanity.
             if (null == objID)
@@ -1357,7 +1357,7 @@ namespace MFaaP.MFWSClient
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>A collection of <see cref="ObjectVersion"/>s representing the object history.</returns>
         /// <remarks>Note that not all versions may be shown: http://www.m-files.com/mfws/resources/objects/type/objectid/history.html</remarks>
-        public List<ObjectVersion> GetHistory(ObjID objID, CancellationToken token = default(CancellationToken))
+        public List<ObjectVersion> GetHistory(ObjID objID, CancellationToken token = default)
         {
             // Execute the async method.
             return this.GetHistoryAsync(objID, token)
@@ -1377,7 +1377,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The <see cref="ObjID"/> of the item to add to the favourites.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was added.</returns>
-        public async Task<ExtendedObjectVersion> AddToFavoritesAsync(ObjID objId, CancellationToken token = default(CancellationToken))
+        public async Task<ExtendedObjectVersion> AddToFavoritesAsync(ObjID objId, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -1401,7 +1401,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The <see cref="ObjID"/> of the item to add to the favourites.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was added.</returns>
-        public ExtendedObjectVersion AddToFavorites(ObjID objId, CancellationToken token = default(CancellationToken))
+        public ExtendedObjectVersion AddToFavorites(ObjID objId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.AddToFavoritesAsync(objId, token)
@@ -1417,7 +1417,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was added.</returns>
-        public Task<ExtendedObjectVersion> AddToFavoritesAsync(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public Task<ExtendedObjectVersion> AddToFavoritesAsync(int objectTypeId, int objectId, CancellationToken token = default)
         {
             return this.AddToFavoritesAsync(new ObjID()
             {
@@ -1433,7 +1433,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was added.</returns>
-        public ExtendedObjectVersion AddToFavorites(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public ExtendedObjectVersion AddToFavorites(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.AddToFavoritesAsync(objectTypeId, objectId, token)
@@ -1448,7 +1448,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The <see cref="ObjID"/> of the item to remove from the favourites.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was removed.</returns>
-        public async Task<ExtendedObjectVersion> RemoveFromFavoritesAsync(ObjID objId, CancellationToken token = default(CancellationToken))
+        public async Task<ExtendedObjectVersion> RemoveFromFavoritesAsync(ObjID objId, CancellationToken token = default)
         {
             // Sanity.
             if (null == objId)
@@ -1471,7 +1471,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objId">The <see cref="ObjID"/> of the item to remove from the favourites.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was removed.</returns>
-        public ExtendedObjectVersion RemoveFromFavorites(ObjID objId, CancellationToken token = default(CancellationToken))
+        public ExtendedObjectVersion RemoveFromFavorites(ObjID objId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.RemoveFromFavoritesAsync(objId, token)
@@ -1487,7 +1487,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was removed.</returns>
-        public Task<ExtendedObjectVersion> RemoveFromFavoritesAsync(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public Task<ExtendedObjectVersion> RemoveFromFavoritesAsync(int objectTypeId, int objectId, CancellationToken token = default)
         {
             return this.RemoveFromFavoritesAsync(new ObjID()
             {
@@ -1503,7 +1503,7 @@ namespace MFaaP.MFWSClient
         /// <param name="objectId">The Id of the object.</param>
         /// <param name="token">A cancellation token for the request.</param>
         /// <returns>The item that was removed.</returns>
-        public ExtendedObjectVersion RemoveFromFavorites(int objectTypeId, int objectId, CancellationToken token = default(CancellationToken))
+        public ExtendedObjectVersion RemoveFromFavorites(int objectTypeId, int objectId, CancellationToken token = default)
         {
             // Execute the async method.
             return this.RemoveFromFavoritesAsync(objectTypeId, objectId, token)

--- a/MFaaP.MFWSClient/MFWSVaultObjectPropertyOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultObjectPropertyOperations.cs
@@ -34,7 +34,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyDef">The property to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property value.</returns>
-		public async Task<PropertyValue> GetPropertyAsync(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default(CancellationToken))
+		public async Task<PropertyValue> GetPropertyAsync(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default)
 		{
 			// Sanity.
 			if (objectTypeId < 0)
@@ -46,7 +46,7 @@ namespace MFaaP.MFWSClient
 
 			// Create the request.
 			var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/{version?.ToString() ?? "latest"}/properties/{propertyDef}");
-			request.Method = Method.GET;
+			request.Method = Method.Get;
 
 			// Make the request and get the response.
 			var response = await this.MFWSClient.Get<PropertyValue>(request, token)
@@ -63,7 +63,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyDef">The property to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property value.</returns>
-		public Task<PropertyValue> GetPropertyAsync(ObjVer objVer, int propertyDef, CancellationToken token = default(CancellationToken))
+		public Task<PropertyValue> GetPropertyAsync(ObjVer objVer, int propertyDef, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.GetPropertyAsync(objVer.Type, objVer.ID, propertyDef, objVer.Version, token);
@@ -76,7 +76,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyDef">The property to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property value.</returns>
-		public Task<PropertyValue> GetPropertyAsync(ObjID objId, int propertyDef, CancellationToken token = default(CancellationToken))
+		public Task<PropertyValue> GetPropertyAsync(ObjID objId, int propertyDef, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.GetPropertyAsync(objId.Type, objId.ID, propertyDef, null, token);
@@ -91,7 +91,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyDef">The property to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property value.</returns>
-		public PropertyValue GetProperty(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default(CancellationToken))
+		public PropertyValue GetProperty(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertyAsync(objectTypeId, objectId, propertyDef, version, token)
@@ -107,7 +107,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyDef">The property to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property value.</returns>
-		public PropertyValue GetProperty(ObjVer objVer, int propertyDef, CancellationToken token = default(CancellationToken))
+		public PropertyValue GetProperty(ObjVer objVer, int propertyDef, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertyAsync(objVer, propertyDef, token)
@@ -123,7 +123,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="propertyDef">The property to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property value.</returns>
-		public PropertyValue GetProperty(ObjID objId, int propertyDef, CancellationToken token = default(CancellationToken))
+		public PropertyValue GetProperty(ObjID objId, int propertyDef, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertyAsync(objId, propertyDef, token)
@@ -220,7 +220,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="version">The version (or null for latest).</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A collection of property values for the supplied object.</returns>
-		public PropertyValue[] GetProperties(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+		public PropertyValue[] GetProperties(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertiesAsync(objectTypeId, objectId, version, token)
@@ -237,7 +237,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="version">The version (or null for latest).</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A collection of property values for the supplied object.</returns>
-		public Task<PropertyValue[]> GetPropertiesAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default(CancellationToken))
+		public Task<PropertyValue[]> GetPropertiesAsync(int objectTypeId, int objectId, int? version = null, CancellationToken token = default)
 		{
 			// Use the other method.
 			return this.GetPropertiesAsync(new ObjVer()
@@ -254,7 +254,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objID">The object to retrieve the properties of.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A collection of property values for the supplied object.</returns>
-		public PropertyValue[] GetProperties(ObjID objID, CancellationToken token = default(CancellationToken))
+		public PropertyValue[] GetProperties(ObjID objID, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertiesAsync(objID, token)
@@ -269,7 +269,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objID">The object to retrieve the properties of.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A collection of property values for the supplied object.</returns>
-		public Task<PropertyValue[]> GetPropertiesAsync(ObjID objID, CancellationToken token = default(CancellationToken))
+		public Task<PropertyValue[]> GetPropertiesAsync(ObjID objID, CancellationToken token = default)
 		{
 			// Use the other method.
 			return this.GetPropertiesAsync(objID.Type, objID.ID, version: null, token: token);
@@ -281,7 +281,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objVer">The object to retrieve the properties of.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A collection of property values for the supplied object.</returns>
-		public PropertyValue[] GetProperties(ObjVer objVer, CancellationToken token = default(CancellationToken))
+		public PropertyValue[] GetProperties(ObjVer objVer, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertiesAsync(objVer, token)
@@ -296,7 +296,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objVer">The object to retrieve the properties of.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A collection of property values for the supplied object.</returns>
-		public async Task<PropertyValue[]> GetPropertiesAsync(ObjVer objVer, CancellationToken token = default(CancellationToken))
+		public async Task<PropertyValue[]> GetPropertiesAsync(ObjVer objVer, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -334,7 +334,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public async Task<ExtendedObjectVersion> SetPropertyAsync(int objectTypeId, int objectId, PropertyValue newPropertyValue, int? version = null, CancellationToken token = default(CancellationToken))
+		public async Task<ExtendedObjectVersion> SetPropertyAsync(int objectTypeId, int objectId, PropertyValue newPropertyValue, int? version = null, CancellationToken token = default)
 		{
 			// Sanity.
 			if (objectTypeId < 0)
@@ -348,7 +348,7 @@ namespace MFaaP.MFWSClient
 
 			// Create the request.
 			var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/{version?.ToString() ?? "latest"}/properties/{newPropertyValue.PropertyDef}");
-			request.Method = Method.PUT;
+			request.Method = Method.Put;
 
 			// Set the request body.
 			request.AddJsonBody(newPropertyValue);
@@ -369,7 +369,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public Task<ExtendedObjectVersion> SetPropertyAsync(ObjVer objVer, PropertyValue newPropertyValue, CancellationToken token = default(CancellationToken))
+		public Task<ExtendedObjectVersion> SetPropertyAsync(ObjVer objVer, PropertyValue newPropertyValue, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.SetPropertyAsync(objVer.Type, objVer.ID, newPropertyValue, objVer.Version, token);
@@ -383,7 +383,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public Task<ExtendedObjectVersion> SetPropertyAsync(ObjID objId, PropertyValue newPropertyValue, CancellationToken token = default(CancellationToken))
+		public Task<ExtendedObjectVersion> SetPropertyAsync(ObjID objId, PropertyValue newPropertyValue, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.SetPropertyAsync(objId.Type, objId.ID, newPropertyValue, null, token);
@@ -399,7 +399,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public ExtendedObjectVersion SetProperty(int objectTypeId, int objectId, PropertyValue newPropertyValue, int? version = null, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion SetProperty(int objectTypeId, int objectId, PropertyValue newPropertyValue, int? version = null, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.SetPropertyAsync(objectTypeId, objectId, newPropertyValue, version, token)
@@ -416,7 +416,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public ExtendedObjectVersion SetProperty(ObjVer objVer, PropertyValue newPropertyValue, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion SetProperty(ObjVer objVer, PropertyValue newPropertyValue, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.SetPropertyAsync(objVer, newPropertyValue, token)
@@ -433,7 +433,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public ExtendedObjectVersion SetProperty(ObjID objId, PropertyValue newPropertyValue, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion SetProperty(ObjID objId, PropertyValue newPropertyValue, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.SetPropertyAsync(objId, newPropertyValue, token)
@@ -457,7 +457,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>If <see paramref="replaceAllProperties"/> is true then <see paramref="propertyValues"/> must contain values for property 0 (name or title), property 100 (class), property 22 (is single file), and any other mandatory properties for the given class.</remarks>
-		public async Task<ExtendedObjectVersion> SetPropertiesAsync(int objectTypeId, int objectId, PropertyValue[] propertyValues, bool replaceAllProperties, int? version = null, CancellationToken token = default(CancellationToken))
+		public async Task<ExtendedObjectVersion> SetPropertiesAsync(int objectTypeId, int objectId, PropertyValue[] propertyValues, bool replaceAllProperties, int? version = null, CancellationToken token = default)
 		{
 			// Sanity.
 			if (objectTypeId < 0)
@@ -470,8 +470,8 @@ namespace MFaaP.MFWSClient
 			// Create the request.
 			var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/{version?.ToString() ?? "latest"}/properties");
 			request.Method = replaceAllProperties
-				? Method.PUT // If we wish to replace all properties then we need to use a PUT.
-				: Method.POST; // A POST will add or replace just the properties provided.
+				? Method.Put // If we wish to replace all properties then we need to use a PUT.
+				: Method.Post; // A POST will add or replace just the properties provided.
 
 			// Set the request body.
 			request.AddJsonBody(propertyValues);
@@ -494,7 +494,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>If <see paramref="replaceAllProperties"/> is true then <see paramref="propertyValues"/> must contain values for property 0 (name or title), property 100 (class), property 22 (is single file), and any other mandatory properties for the given class.</remarks>
-		public Task<ExtendedObjectVersion> SetPropertiesAsync(ObjVer objVer, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default(CancellationToken))
+		public Task<ExtendedObjectVersion> SetPropertiesAsync(ObjVer objVer, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.SetPropertiesAsync(objVer.Type, objVer.ID, propertyValues, replaceAllProperties, objVer.Version, token);
@@ -509,7 +509,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>If <see paramref="replaceAllProperties"/> is true then <see paramref="propertyValues"/> must contain values for property 0 (name or title), property 100 (class), property 22 (is single file), and any other mandatory properties for the given class.</remarks>
-		public Task<ExtendedObjectVersion> SetPropertiesAsync(ObjID objId, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default(CancellationToken))
+		public Task<ExtendedObjectVersion> SetPropertiesAsync(ObjID objId, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.SetPropertiesAsync(objId.Type, objId.ID, propertyValues, replaceAllProperties, null, token);
@@ -526,7 +526,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>If <see paramref="replaceAllProperties"/> is true then <see paramref="propertyValues"/> must contain values for property 0 (name or title), property 100 (class), property 22 (is single file), and any other mandatory properties for the given class.</remarks>
-		public ExtendedObjectVersion SetProperties(int objectTypeId, int objectId, PropertyValue[] propertyValues, bool replaceAllProperties, int? version = null, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion SetProperties(int objectTypeId, int objectId, PropertyValue[] propertyValues, bool replaceAllProperties, int? version = null, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.SetPropertiesAsync(objectTypeId, objectId, propertyValues, replaceAllProperties, version, token)
@@ -544,7 +544,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>If <see paramref="replaceAllProperties"/> is true then <see paramref="propertyValues"/> must contain values for property 0 (name or title), property 100 (class), property 22 (is single file), and any other mandatory properties for the given class.</remarks>
-		public ExtendedObjectVersion SetProperties(ObjVer objVer, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion SetProperties(ObjVer objVer, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.SetPropertiesAsync(objVer, propertyValues, replaceAllProperties, token)
@@ -562,7 +562,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>If <see paramref="replaceAllProperties"/> is true then <see paramref="propertyValues"/> must contain values for property 0 (name or title), property 100 (class), property 22 (is single file), and any other mandatory properties for the given class.</remarks>
-		public ExtendedObjectVersion SetProperties(ObjID objId, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion SetProperties(ObjID objId, PropertyValue[] propertyValues, bool replaceAllProperties, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.SetPropertiesAsync(objId, propertyValues, replaceAllProperties, token)
@@ -581,7 +581,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersionUpdateInformation">Information on the objects to promote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>Will also promote objects if they are external and a class property value is provided (see <see cref="MFWSVaultExternalObjectOperations.PromoteObjectsAsync"/>).</remarks>
-		public async Task<List<ExtendedObjectVersion>> SetPropertiesOfMultipleObjectsAsync(CancellationToken token = default(CancellationToken), params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
+		public async Task<List<ExtendedObjectVersion>> SetPropertiesOfMultipleObjectsAsync(CancellationToken token = default, params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
 		{
 			// Sanity.
 			if (null == objectVersionUpdateInformation)
@@ -613,7 +613,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="objectVersionUpdateInformation">Information on the objects to promote.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>The property values must be valid for the class, as they would if an object were being created.</remarks>
-		public List<ExtendedObjectVersion> SetPropertiesOfMultipleObjects(CancellationToken token = default(CancellationToken), params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
+		public List<ExtendedObjectVersion> SetPropertiesOfMultipleObjects(CancellationToken token = default, params ObjectVersionUpdateInformation[] objectVersionUpdateInformation)
 		{
 			// Execute the async method.
 			return this.SetPropertiesOfMultipleObjectsAsync(token, objectVersionUpdateInformation)
@@ -636,7 +636,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public async Task<ExtendedObjectVersion> RemovePropertyAsync(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default(CancellationToken))
+		public async Task<ExtendedObjectVersion> RemovePropertyAsync(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default)
 		{
 			// Sanity.
 			if (objectTypeId < 0)
@@ -648,7 +648,7 @@ namespace MFaaP.MFWSClient
 
 			// Create the request.
 			var request = new RestRequest($"/REST/objects/{objectTypeId}/{objectId}/{version?.ToString() ?? "latest"}/properties/{propertyDef}.aspx");
-			request.Method = Method.DELETE;
+			request.Method = Method.Delete;
 
 			// Make the request and get the response.
 			var response = await this.MFWSClient.Delete<ExtendedObjectVersion>(request, token)
@@ -666,7 +666,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public Task<ExtendedObjectVersion> RemovePropertyAsync(ObjVer objVer, int propertyDef, CancellationToken token = default(CancellationToken))
+		public Task<ExtendedObjectVersion> RemovePropertyAsync(ObjVer objVer, int propertyDef, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.RemovePropertyAsync(objVer.Type, objVer.ID, propertyDef, objVer.Version, token);
@@ -680,7 +680,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public Task<ExtendedObjectVersion> RemovePropertyAsync(ObjID objId, int propertyDef, CancellationToken token = default(CancellationToken))
+		public Task<ExtendedObjectVersion> RemovePropertyAsync(ObjID objId, int propertyDef, CancellationToken token = default)
 		{
 			// Use the other overload.
 			return this.RemovePropertyAsync(objId.Type, objId.ID, propertyDef, null, token);
@@ -696,7 +696,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public ExtendedObjectVersion RemoveProperty(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion RemoveProperty(int objectTypeId, int objectId, int propertyDef, int? version = null, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.RemovePropertyAsync(objectTypeId, objectId, propertyDef, version, token)
@@ -713,7 +713,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public ExtendedObjectVersion RemoveProperty(ObjVer objVer, int propertyDef, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion RemoveProperty(ObjVer objVer, int propertyDef, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.RemovePropertyAsync(objVer, propertyDef, token)
@@ -730,7 +730,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The new object version.</returns>
 		/// <remarks>The object must be checked out to perform this action.</remarks>
-		public ExtendedObjectVersion RemoveProperty(ObjID objId, int propertyDef, CancellationToken token = default(CancellationToken))
+		public ExtendedObjectVersion RemoveProperty(ObjID objId, int propertyDef, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.RemovePropertyAsync(objId, propertyDef, token)
@@ -755,12 +755,12 @@ namespace MFaaP.MFWSClient
 		(
 			int assignmentObjectId,
 			int? version = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/objects/{assignmentObjectId}/{version?.ToString() ?? "latest"}/canCompleteAssignment.aspx");
-			request.Method = Method.GET;
+			request.Method = Method.Get;
 
 			// Make the request and get the response.
 			var response = await this.MFWSClient.Get<PrimitiveType<bool>>(request, token)
@@ -778,7 +778,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="version">The version of the assignment object, or null to use the latest.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>Whether the user can complete the assignment.</returns>
-		public PrimitiveType<bool> CanCompleteAssignment(int assignmentObjectId, int? version = null, CancellationToken token = default(CancellationToken))
+		public PrimitiveType<bool> CanCompleteAssignment(int assignmentObjectId, int? version = null, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.CanCompleteAssignmentAsync(assignmentObjectId, version, token)
@@ -799,7 +799,7 @@ namespace MFaaP.MFWSClient
 		(
 			ObjID objId,
 			int? version = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Sanity.
@@ -822,7 +822,7 @@ namespace MFaaP.MFWSClient
 		(
 			ObjID objId, 
 			int? version = null, 
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -842,7 +842,7 @@ namespace MFaaP.MFWSClient
 		public Task<PrimitiveType<bool>> CanCompleteAssignmentAsync
 		(
 			ObjVer objVer,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Sanity.
@@ -863,7 +863,7 @@ namespace MFaaP.MFWSClient
 		public PrimitiveType<bool> CanCompleteAssignment
 		(
 			ObjVer objVer,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -890,7 +890,7 @@ namespace MFaaP.MFWSClient
 			int objectId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			return this.ApproveOrRejectAssignmentAsync
@@ -917,7 +917,7 @@ namespace MFaaP.MFWSClient
 			int objectId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -940,7 +940,7 @@ namespace MFaaP.MFWSClient
 			ObjID objId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Sanity.
@@ -964,7 +964,7 @@ namespace MFaaP.MFWSClient
 			ObjID objId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -985,7 +985,7 @@ namespace MFaaP.MFWSClient
 		(
 			ObjVer objVer,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Sanity.
@@ -1007,7 +1007,7 @@ namespace MFaaP.MFWSClient
 		(
 			ObjVer objVer,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -1030,7 +1030,7 @@ namespace MFaaP.MFWSClient
 			int objectId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			return this.ApproveOrRejectAssignmentAsync
@@ -1057,7 +1057,7 @@ namespace MFaaP.MFWSClient
 			int objectId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -1080,7 +1080,7 @@ namespace MFaaP.MFWSClient
 			ObjID objId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Sanity.
@@ -1104,7 +1104,7 @@ namespace MFaaP.MFWSClient
 			ObjID objId,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -1125,7 +1125,7 @@ namespace MFaaP.MFWSClient
 		(
 			ObjVer objVer,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Sanity.
@@ -1147,7 +1147,7 @@ namespace MFaaP.MFWSClient
 		(
 			ObjVer objVer,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -1174,7 +1174,7 @@ namespace MFaaP.MFWSClient
 			bool approve,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Sanity.
@@ -1188,7 +1188,7 @@ namespace MFaaP.MFWSClient
 
 			// Create the request.
 			var request = new RestRequest(uri);
-			request.Method = Method.PUT;
+			request.Method = Method.Put;
 
 			// If we are rejecting then we need the MFWA extension...
 			if (false == approve)
@@ -1225,7 +1225,7 @@ namespace MFaaP.MFWSClient
 			bool approve,
 			int? version = null,
 			string comment = null,
-			CancellationToken token = default(CancellationToken)
+			CancellationToken token = default
 		)
 		{
 			// Execute the async method.
@@ -1246,7 +1246,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="stateId">workflow State ID which needs to be set</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A representation of the updated object version</returns>
-		public async Task<ObjectVersion> SetWorkflowStateAsync(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
+		public async Task<ObjectVersion> SetWorkflowStateAsync(ObjVer objVer, int stateId, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == objVer)
@@ -1254,7 +1254,7 @@ namespace MFaaP.MFWSClient
 
 			// Create the request.
 			var request = new RestRequest($"/REST/objects/{objVer.Type}/{objVer.ID}/{objVer.Version}/workflowstate");
-			request.Method = Method.PUT;
+			request.Method = Method.Put;
 			request.AddJsonBody(new ObjectWorkflowState() { StateID = stateId });
 			// Execute the request and parse the response.
 			var response = await this.MFWSClient.Put<ExtendedObjectVersion>(request, token).ConfigureAwait(false);
@@ -1269,7 +1269,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="stateId">workflow State ID which needs to be set</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A representation of the updated object version</returns>
-		public ObjectVersion SetWorkflowState(ObjVer objVer, int stateId, CancellationToken token = default(CancellationToken))
+		public ObjectVersion SetWorkflowState(ObjVer objVer, int stateId, CancellationToken token = default)
 		{
 			return this.SetWorkflowStateAsync(objVer, stateId, token)
 				.ConfigureAwait(false)

--- a/MFaaP.MFWSClient/MFWSVaultObjectSearchOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultObjectSearchOperations.cs
@@ -34,7 +34,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An array of items that match the search term.</returns>
 		/// <remarks>For more comprehensive search options, construct a series of <see cref="ISearchCondition"/> objects and use the <see cref="SearchForObjectsByString"/> method.</remarks>
-		public Task<ObjectVersion[]> SearchForObjectsByStringAsync(string searchTerm, int? objectTypeId = null, int limit = defaultSearchLimit, CancellationToken token = default(CancellationToken))
+		public Task<ObjectVersion[]> SearchForObjectsByStringAsync(string searchTerm, int? objectTypeId = null, int limit = defaultSearchLimit, CancellationToken token = default)
 		{
 			// Create a collection of conditions.
 			var conditions = new List<ISearchCondition>
@@ -62,7 +62,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An array of items that match the search term.</returns>
 		/// <remarks>For more comprehensive search options, construct a series of <see cref="ISearchCondition"/> objects and use the <see cref="SearchForObjectsByString"/> method.</remarks>
-		public ObjectVersion[] SearchForObjectsByString(string searchTerm, int? objectTypeId = null, int limit = defaultSearchLimit, CancellationToken token = default(CancellationToken))
+		public ObjectVersion[] SearchForObjectsByString(string searchTerm, int? objectTypeId = null, int limit = defaultSearchLimit, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.SearchForObjectsByStringAsync(searchTerm, objectTypeId, limit, token)

--- a/MFaaP.MFWSClient/MFWSVaultObjectTypeOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultObjectTypeOperations.cs
@@ -31,7 +31,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no object types have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<int> GetObjectTypeIDByAliasAsync(string alias, CancellationToken token = default(CancellationToken))
+		public async Task<int> GetObjectTypeIDByAliasAsync(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = await this.GetObjectTypeIDsByAliasesAsync(token, aliases: new string[] { alias });
@@ -48,7 +48,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no object type have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<List<int>> GetObjectTypeIDsByAliasesAsync(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public async Task<List<int>> GetObjectTypeIDsByAliasesAsync(CancellationToken token = default, params string[] aliases)
 		{
 			// Sanity.
 			if (null == aliases)
@@ -77,7 +77,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no object type have the alias, or more than one does).</remarks>
-		public List<int> GetObjectTypeIDsByAliases(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public List<int> GetObjectTypeIDsByAliases(CancellationToken token = default, params string[] aliases)
 		{
 			// Execute the async method.
 			return this.GetObjectTypeIDsByAliasesAsync(token, aliases)
@@ -94,7 +94,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no object types have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public int GetObjectTypeIDByAlias(string alias, CancellationToken token = default(CancellationToken))
+		public int GetObjectTypeIDByAlias(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = this.GetObjectTypeIDsByAliases(token, aliases: new string[] { alias });
@@ -111,7 +111,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All object types in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public async Task<List<ObjType>> GetObjectTypesAsync(CancellationToken token = default(CancellationToken))
+		public async Task<List<ObjType>> GetObjectTypesAsync(CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/structure/objecttypes.aspx");
@@ -130,7 +130,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All object types in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public List<ObjType> GetObjectTypes(CancellationToken token = default(CancellationToken))
+		public List<ObjType> GetObjectTypes(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetObjectTypesAsync(token)

--- a/MFaaP.MFWSClient/MFWSVaultOperationsBase.cs
+++ b/MFaaP.MFWSClient/MFWSVaultOperationsBase.cs
@@ -18,10 +18,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="client">The client to interact with the server.</param>
 		internal MFWSVaultOperationsBase(MFWSClientBase client)
 		{
-			// Sanity.
-			if (null == client)
-				throw new ArgumentNullException(nameof(client));
-			this.MFWSClient = client;
+            this.MFWSClient = client ?? throw new ArgumentNullException(nameof(client));
 		}
 	}
 }

--- a/MFaaP.MFWSClient/MFWSVaultPropertyDefOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultPropertyDefOperations.cs
@@ -31,7 +31,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no property definitions have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<int> GetPropertyDefIDByAliasAsync(string alias, CancellationToken token = default(CancellationToken))
+		public async Task<int> GetPropertyDefIDByAliasAsync(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = await this.GetPropertyDefIDsByAliasesAsync(token, aliases: new string[] { alias });
@@ -48,7 +48,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no property definitions have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<List<int>> GetPropertyDefIDsByAliasesAsync(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public async Task<List<int>> GetPropertyDefIDsByAliasesAsync(CancellationToken token = default, params string[] aliases)
 		{
 			// Sanity.
 			if(null == aliases)
@@ -77,7 +77,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>A collection of resolved IDs.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no property definitions have the alias, or more than one does).</remarks>
-		public List<int> GetPropertyDefIDsByAliases(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public List<int> GetPropertyDefIDsByAliases(CancellationToken token = default, params string[] aliases)
 		{
 			// Execute the async method.
 			return this.GetPropertyDefIDsByAliasesAsync(token, aliases)
@@ -94,7 +94,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no property definitions have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public int GetPropertyDefIDByAlias(string alias, CancellationToken token = default(CancellationToken))
+		public int GetPropertyDefIDByAlias(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = this.GetPropertyDefIDsByAliases(token, aliases: new string[] { alias });
@@ -111,7 +111,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All property definitions in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public async Task<List<PropertyDef>> GetPropertyDefsAsync(CancellationToken token = default(CancellationToken))
+		public async Task<List<PropertyDef>> GetPropertyDefsAsync(CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/structure/properties");
@@ -130,7 +130,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All property definitions in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public List<PropertyDef> GetPropertyDefs(CancellationToken token = default(CancellationToken))
+		public List<PropertyDef> GetPropertyDefs(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertyDefsAsync(token)
@@ -146,7 +146,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property definition.</returns>
 		/// <remarks>This may be affected by the user's permissions.</remarks>
-		public async Task<PropertyDef> GetPropertyDefAsync(int propertyDefId, CancellationToken token = default(CancellationToken))
+		public async Task<PropertyDef> GetPropertyDefAsync(int propertyDefId, CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/structure/properties/{propertyDefId}");
@@ -166,7 +166,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The property definition.</returns>
 		/// <remarks>This may be affected by the user's permissions.</remarks>
-		public PropertyDef GetPropertyDef(int propertyDefId, CancellationToken token = default(CancellationToken))
+		public PropertyDef GetPropertyDef(int propertyDefId, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetPropertyDefAsync(propertyDefId, token)

--- a/MFaaP.MFWSClient/MFWSVaultValueListItemOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultValueListItemOperations.cs
@@ -28,7 +28,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="limit">If 0, uses Mfiles default at server (default 500 items returned)</param>
 		/// <returns>The contents of the value list.</returns>
 		/// <remarks>Note that this may be limited.</remarks>
-		public async Task<Results<ValueListItem>> GetValueListItemsAsync(int valueListId, string nameFilter = null, CancellationToken token = default(CancellationToken), int limit = 0)
+		public async Task<Results<ValueListItem>> GetValueListItemsAsync(int valueListId, string nameFilter = null, CancellationToken token = default, int limit = 0)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/valuelists/{valueListId}/items");
@@ -63,7 +63,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="limit">If 0, uses Mfiles default at server (default 500 items returned)</param>
 		/// <returns>The contents of the value list.</returns>
 		/// <remarks>Note that this may be limited.</remarks>
-		public Results<ValueListItem> GetValueListItems(int valueListId, string nameFilter = null, CancellationToken token = default(CancellationToken), int limit = 0)
+		public Results<ValueListItem> GetValueListItems(int valueListId, string nameFilter = null, CancellationToken token = default, int limit = 0)
 		{
 			// Execute the async method.
 			return this.GetValueListItemsAsync(valueListId, nameFilter, token, limit)
@@ -80,7 +80,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="newItemName">Name of the new value list item to create.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The newly created value list item</returns>
-		public Task<ValueListItem> AddValueListItemAsync(int valueListId, string newItemName, CancellationToken token = default(CancellationToken))
+		public Task<ValueListItem> AddValueListItemAsync(int valueListId, string newItemName, CancellationToken token = default)
 		{
 			// Sanity.
 			if (string.IsNullOrWhiteSpace(newItemName))
@@ -103,7 +103,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="newItemName">Name of the new value list item to create.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The newly created value list item</returns>
-		public ValueListItem AddValueListItem(int valueListId, string newItemName, CancellationToken token = default(CancellationToken))
+		public ValueListItem AddValueListItem(int valueListId, string newItemName, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.AddValueListItemAsync(valueListId, newItemName, token)
@@ -119,7 +119,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="valueListItem">The value list item to create.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The newly created value list item</returns>
-		public async Task<ValueListItem> AddValueListItemAsync(int valueListId, ValueListItem valueListItem, CancellationToken token = default(CancellationToken))
+		public async Task<ValueListItem> AddValueListItemAsync(int valueListId, ValueListItem valueListItem, CancellationToken token = default)
 		{
 			// Sanity.
 			if (null == valueListItem)
@@ -147,7 +147,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="valueListItem">The value list item to create.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The newly created value list item</returns>
-		public ValueListItem AddValueListItem(int valueListId, ValueListItem valueListItem, CancellationToken token = default(CancellationToken))
+		public ValueListItem AddValueListItem(int valueListId, ValueListItem valueListItem, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.AddValueListItemAsync(valueListId, valueListItem, token)

--- a/MFaaP.MFWSClient/MFWSVaultValueListOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultValueListOperations.cs
@@ -30,7 +30,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no value lists have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<int> GetValueListIDByAliasAsync(string alias, CancellationToken token = default(CancellationToken))
+		public async Task<int> GetValueListIDByAliasAsync(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = await this.GetValueListIDsByAliasesAsync(token, aliases: new string[] { alias });
@@ -47,7 +47,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no value lists have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<List<int>> GetValueListIDsByAliasesAsync(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public async Task<List<int>> GetValueListIDsByAliasesAsync(CancellationToken token = default, params string[] aliases)
 		{
 			// Sanity.
 			if (null == aliases)
@@ -76,7 +76,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no value lists have the alias, or more than one does).</remarks>
-		public List<int> GetValueListIDsByAliases(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public List<int> GetValueListIDsByAliases(CancellationToken token = default, params string[] aliases)
 		{
 			// Execute the async method.
 			return this.GetValueListIDsByAliasesAsync(token, aliases)
@@ -93,7 +93,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no value lists have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public int GetValueListIDByAlias(string alias, CancellationToken token = default(CancellationToken))
+		public int GetValueListIDByAlias(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = this.GetValueListIDsByAliases(token, aliases: new string[] { alias });
@@ -110,7 +110,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All value lists in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public async Task<List<ObjType>> GetValueListsAsync(CancellationToken token = default(CancellationToken))
+		public async Task<List<ObjType>> GetValueListsAsync(CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/valuelists.aspx");
@@ -129,7 +129,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>All value lists in the vault.</returns>
 		/// <remarks>This may be filtered by the user's permissions.</remarks>
-		public List<ObjType> GetValueLists(CancellationToken token = default(CancellationToken))
+		public List<ObjType> GetValueLists(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetValueListsAsync(token)

--- a/MFaaP.MFWSClient/MFWSVaultViewOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultViewOperations.cs
@@ -26,7 +26,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>The contents of the view.</returns>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>Identical to calling <see cref="GetFolderContentsAsync(MFaaP.MFWSClient.FolderContentItem[])"/> with no parameters.</remarks>
-		public Task<FolderContentItems> GetRootFolderContentsAsync(CancellationToken token = default(CancellationToken))
+		public Task<FolderContentItems> GetRootFolderContentsAsync(CancellationToken token = default)
 		{
 			// Get the root view contents.
 			return this.GetFolderContentsAsync(token);
@@ -38,7 +38,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>The contents of the view.</returns>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <remarks>Identical to calling <see cref="GetFolderContents(MFaaP.MFWSClient.FolderContentItem[])"/> with no parameters.</remarks>
-		public FolderContentItems GetRootFolderContents(CancellationToken token = default(CancellationToken))
+		public FolderContentItems GetRootFolderContents(CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetRootFolderContentsAsync(token)
@@ -179,7 +179,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="builtInView">An enumeration of the built-in view to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The favorited items.</returns>
-		public async Task<List<FolderContentItems>> GetFolderContentsAsync(MFBuiltInView builtInView, CancellationToken token = default(CancellationToken))
+		public async Task<List<FolderContentItems>> GetFolderContentsAsync(MFBuiltInView builtInView, CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/views/v{(int)builtInView}/items");
@@ -198,7 +198,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="builtInView">An enumeration of the built-in view to retrieve.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>The favorited items.</returns>
-		public List<FolderContentItems> GetFolderContents(MFBuiltInView builtInView, CancellationToken token = default(CancellationToken))
+		public List<FolderContentItems> GetFolderContents(MFBuiltInView builtInView, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetFolderContentsAsync(builtInView, token)

--- a/MFaaP.MFWSClient/MFWSVaultWorkflowOperations.cs
+++ b/MFaaP.MFWSClient/MFWSVaultWorkflowOperations.cs
@@ -29,7 +29,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="workflowId">The workflow identifier.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
-		public async Task<WorkflowState[]> GetWorkflowStatesAsync(int workflowId, CancellationToken token = default(CancellationToken))
+		public async Task<WorkflowState[]> GetWorkflowStatesAsync(int workflowId, CancellationToken token = default)
 		{
 			// Create the request.
 			var request = new RestRequest($"/REST/structure/workflows/{workflowId}/states.aspx");
@@ -47,7 +47,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="workflowId">The workflow identifier.</param>
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
-		public WorkflowState[] GetWorkflowStates(int workflowId, CancellationToken token = default(CancellationToken))
+		public WorkflowState[] GetWorkflowStates(int workflowId, CancellationToken token = default)
 		{
 			// Execute the async method.
 			return this.GetWorkflowStatesAsync(workflowId, token)
@@ -64,7 +64,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.  Task will return null if no state with that name is found.</returns>
 		/// <remarks>Note that this will retrieve all workflow states from the server and then filter them by the name, so will be inefficient to call multiple times.</remarks>
-		public WorkflowState GetWorkflowStateByName(int workflowId, string stateName, CancellationToken token = default(CancellationToken))
+		public WorkflowState GetWorkflowStateByName(int workflowId, string stateName, CancellationToken token = default)
 		{
 			// Get all the states.
 			var workflowStates = this.GetWorkflowStates(workflowId, token);
@@ -85,7 +85,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflows have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<int> GetWorkflowIDByAliasAsync(string alias, CancellationToken token = default(CancellationToken))
+		public async Task<int> GetWorkflowIDByAliasAsync(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = await this.GetWorkflowIDsByAliasesAsync(token, aliases: new string[] { alias });
@@ -102,7 +102,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflows have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<List<int>> GetWorkflowIDsByAliasesAsync(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public async Task<List<int>> GetWorkflowIDsByAliasesAsync(CancellationToken token = default, params string[] aliases)
 		{
 			// Sanity.
 			if (null == aliases)
@@ -131,7 +131,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflows have the alias, or more than one does).</remarks>
-		public List<int> GetWorkflowIDsByAliases(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public List<int> GetWorkflowIDsByAliases(CancellationToken token = default, params string[] aliases)
 		{
 			// Execute the async method.
 			return this.GetWorkflowIDsByAliasesAsync(token, aliases)
@@ -148,7 +148,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflows have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public int GetWorkflowIDByAlias(string alias, CancellationToken token = default(CancellationToken))
+		public int GetWorkflowIDByAlias(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = this.GetWorkflowIDsByAliases(token, aliases: new string[] { alias });
@@ -169,7 +169,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow states have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<int> GetWorkflowStateIDByAliasAsync(string alias, CancellationToken token = default(CancellationToken))
+		public async Task<int> GetWorkflowStateIDByAliasAsync(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = await this.GetWorkflowStateIDsByAliasesAsync(token, aliases: new string[] { alias });
@@ -186,7 +186,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow states have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<List<int>> GetWorkflowStateIDsByAliasesAsync(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public async Task<List<int>> GetWorkflowStateIDsByAliasesAsync(CancellationToken token = default, params string[] aliases)
 		{
 			// Sanity.
 			if (null == aliases)
@@ -215,7 +215,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow states have the alias, or more than one does).</remarks>
-		public List<int> GetWorkflowStateIDsByAliases(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public List<int> GetWorkflowStateIDsByAliases(CancellationToken token = default, params string[] aliases)
 		{
 			// Execute the async method.
 			return this.GetWorkflowStateIDsByAliasesAsync(token, aliases)
@@ -232,7 +232,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow states have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public int GetWorkflowStateIDByAlias(string alias, CancellationToken token = default(CancellationToken))
+		public int GetWorkflowStateIDByAlias(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = this.GetWorkflowStateIDsByAliases(token, aliases: new string[] { alias });
@@ -253,7 +253,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow state transitions have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<int> GetWorkflowStateTransitionIDByAliasAsync(string alias, CancellationToken token = default(CancellationToken))
+		public async Task<int> GetWorkflowStateTransitionIDByAliasAsync(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = await this.GetWorkflowStateTransitionIDsByAliasesAsync(token, aliases: new string[] { alias });
@@ -270,7 +270,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow state transitions have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public async Task<List<int>> GetWorkflowStateTransitionIDsByAliasesAsync(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public async Task<List<int>> GetWorkflowStateTransitionIDsByAliasesAsync(CancellationToken token = default, params string[] aliases)
 		{
 			// Sanity.
 			if (null == aliases)
@@ -299,7 +299,7 @@ namespace MFaaP.MFWSClient
 		/// <param name="token">A cancellation token for the request.</param>
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow state transitions have the alias, or more than one does).</remarks>
-		public List<int> GetWorkflowStateTransitionIDsByAliases(CancellationToken token = default(CancellationToken), params string[] aliases)
+		public List<int> GetWorkflowStateTransitionIDsByAliases(CancellationToken token = default, params string[] aliases)
 		{
 			// Execute the async method.
 			return this.GetWorkflowStateTransitionIDsByAliasesAsync(token, aliases)
@@ -316,7 +316,7 @@ namespace MFaaP.MFWSClient
 		/// <returns>An awaitable task for the request.</returns>
 		/// <remarks>Returns -1 if the alias cannot be resolved (e.g. no workflow state transitions have the alias, or more than one does).</remarks>
 		/// <remarks>Only available in M-Files 12.0.6768.0 upwards.</remarks>
-		public int GetWorkflowStateTransitionIDByAlias(string alias, CancellationToken token = default(CancellationToken))
+		public int GetWorkflowStateTransitionIDByAlias(string alias, CancellationToken token = default)
 		{
 			// Use the other overload.
 			var output = this.GetWorkflowStateTransitionIDsByAliases(token, aliases: new string[] { alias });

--- a/MFaaP.MFWSClient/MFaaP.MFWSClient.csproj
+++ b/MFaaP.MFWSClient/MFaaP.MFWSClient.csproj
@@ -1,20 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46;net48</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net48;net50;net60</TargetFrameworks>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+	
+	<PropertyGroup>
+		<LangVersion>9.0</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+
+	<ItemGroup>
+    <Compile Remove="Properties\**" />
+    <EmbeddedResource Remove="Properties\**" />
+    <None Remove="Properties\**" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <PackageReference Include="RestSharp" Version="108.0.2" />
   </ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net48'))">
+		<Reference Include="System.Web.dll" />
+		<Reference Include="System.Net.Http" Version="4.0.0.0" />
+	</ItemGroup>
   
   <PropertyGroup>
-    <Version>1.3.0-alpha</Version>
     <Authors>M-Files Corporation</Authors>
     <Description>Sample .NET wrapper for the M-Files Web Service.  Not designed for production use.</Description>
     <Copyright>Copyright (c) 2020 onwards, M-Files Corporation</Copyright>
@@ -28,6 +38,8 @@
     <RepositoryUrl>https://github.com/M-Files/Libraries.MFWSClient</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes></PackageReleaseNotes>
+	<VersionPrefix>2.0.0</VersionPrefix>
+	<VersionSuffix>issue-20</VersionSuffix>
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="Pack" Condition=" '$(Configuration)' == 'Release'">

--- a/MFaaP.MFWSClient/MFaaP.MFWSClient.csproj
+++ b/MFaaP.MFWSClient/MFaaP.MFWSClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net48;net50;net60</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net48;net50;net60</TargetFrameworks>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 	
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="108.0.2" />
   </ItemGroup>
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net48'))">
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
 		<Reference Include="System.Web.dll" />
 		<Reference Include="System.Net.Http" Version="4.0.0.0" />
 	</ItemGroup>
@@ -38,7 +38,7 @@
     <RepositoryUrl>https://github.com/M-Files/Libraries.MFWSClient</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes></PackageReleaseNotes>
-	<VersionPrefix>2.0.0</VersionPrefix>
+	<VersionPrefix>2.0.1</VersionPrefix>
 	<VersionSuffix>issue-20</VersionSuffix>
   </PropertyGroup>
   

--- a/MFaaP.MFWSClient/OAuth2/OAuth2TokenResponse.cs
+++ b/MFaaP.MFWSClient/OAuth2/OAuth2TokenResponse.cs
@@ -1,4 +1,4 @@
-﻿using RestSharp.Deserializers;
+﻿using System.Text.Json.Serialization;
 
 namespace MFaaP.MFWSClient.OAuth2
 {
@@ -13,59 +13,59 @@ namespace MFaaP.MFWSClient.OAuth2
 		/// <summary>
 		/// The token type.  Should be "Bearer".
 		/// </summary>
-		[DeserializeAs(Name = "token_type")]
+		[JsonPropertyName("token_type")]
 		public string TokenType { get; set; }
 
 		/// <summary>
 		/// Any scopes defined for the tokens.
 		/// </summary>
-		[DeserializeAs(Name = "scope")]
+		[JsonPropertyName("scope")]
 		public string Scope { get; set; }
 
 		/// <summary>
 		/// How long - since the original request - the access token is valid for.
 		/// </summary>
-		[DeserializeAs(Name = "expires_in")]
+		[JsonPropertyName("expires_in")]
 		public long ExpiresIn { get; set; }
 
-		//[DeserializeAs(Name = "ext_expires_in")]
+		//[JsonPropertyName("ext_expires_in")]
 		//public long ExtExpiresIn { get; set; }
 
 		/// <summary>
 		/// When the access token expires.
 		/// </summary>
-		[DeserializeAs(Name = "expires_on")]
+		[JsonPropertyName("expires_on")]
 		public long ExpiresOn { get; set; }
 
 		/// <summary>
 		/// When token becomes valid.
 		/// </summary>
 
-		[DeserializeAs(Name = "not_before")]
+		[JsonPropertyName("not_before")]
 		public long NotBefore { get; set; }
 
 		/// <summary>
 		/// The resource this token is for.
 		/// </summary>
-		[DeserializeAs(Name = "resource")]
+		[JsonPropertyName("resource")]
 		public string Resource { get; set; }
 
 		/// <summary>
 		/// The access token.
 		/// </summary>
-		[DeserializeAs(Name = "access_token")]
+		[JsonPropertyName("access_token")]
 		public string AccessToken { get; set; }
 
 		/// <summary>
 		/// The refresh token.
 		/// </summary>
-		[DeserializeAs(Name = "refresh_token")]
+		[JsonPropertyName("refresh_token")]
 		public string RefreshToken { get; set; }
 
 		/// <summary>
 		/// The ID token.
 		/// </summary>
-		[DeserializeAs(Name = "id_token")]
+		[JsonPropertyName("id_token")]
 		public string IdToken { get; set; }
 
 	}

--- a/MFaaP.MFWSClient/RestRequestEventArgs.cs
+++ b/MFaaP.MFWSClient/RestRequestEventArgs.cs
@@ -16,13 +16,13 @@ namespace MFaaP.MFWSClient
 		/// <summary>
 		/// The request being executed.
 		/// </summary>
-		public IRestRequest RestRequest { get; private set; }
+		public RestRequest RestRequest { get; private set; }
 
 		/// <summary>
 		/// Instantiates a <see cref="RestRequestEventArgs"/> for the supplied request.
 		/// </summary>
 		/// <param name="restRequest">The request being executed.</param>
-		public RestRequestEventArgs(IRestRequest restRequest)
+		public RestRequestEventArgs(RestRequest restRequest)
 		{
 			this.RestRequest = restRequest;
 		}

--- a/MFaaP.MFWSClient/RestResponseEventArgs.cs
+++ b/MFaaP.MFWSClient/RestResponseEventArgs.cs
@@ -16,13 +16,13 @@ namespace MFaaP.MFWSClient
 		/// <summary>
 		/// The response from the request.
 		/// </summary>
-		public IRestResponse RestResponse { get; private set; }
+		public RestResponse RestResponse { get; private set; }
 
 		/// <summary>
 		/// Instantiates a <see cref="RestResponseEventArgs"/> for the supplied response.
 		/// </summary>
 		/// <param name="restResponse">The response from the request.</param>
-		public RestResponseEventArgs(IRestResponse restResponse)
+		public RestResponseEventArgs(RestResponse restResponse)
 		{
 			this.RestResponse = restResponse;
 		}


### PR DESCRIPTION
Initial implementation for issue #20 

Specifically:
* Updated to use RestSharp 108.2 (latest stable)
* Updated to produce a single .NET package for dotnet Standard 2.0, .NET 4.8, .NET 5.0 and .NET 6.0.
* Drops support for .NET Framework < 4.6.2.

Proposed to be release version 2.0.