### PR TITLE
fix msbuild after pack task

### DIFF
--- a/MFaaP.MFWSClient/MFaaP.MFWSClient.csproj
+++ b/MFaaP.MFWSClient/MFaaP.MFWSClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netstandard2.0</TargetFramework>
+	<TargetFrameworks>netstandard2.0</TargetFrameworks>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 	


### PR DESCRIPTION
using TargetFramework vs TargetFrameworks seems to affect the [OutputPath ](https://github.com/feinoujc/Libraries.MFWSClient/blob/dcb7918b458d513a3dd0546f1dd794c7328e5b07/MFaaP.MFWSClient/MFaaP.MFWSClient.csproj#L40)variable and causes the build to fail